### PR TITLE
Fix reference to released plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In the build plugins section add the plugin with a goal of createSPDX:
                 <plugin>
                     <groupId>org.spdx</groupId>
                     <artifactId>spdx-maven-plugin</artifactId>
-                    <version>0.3.1-SNAPSHOT</version>
+                    <version>0.4.0</version>
                     <executions>
                         <execution>
                             <id>build-spdx</id>


### PR DESCRIPTION
On Maven Central, there was no 0.3.1-SNAPSHOT version. I updated it to the latest available version (see https://mvnrepository.com/artifact/org.spdx/spdx-maven-plugin).