### PR TITLE
Sonarcloud badges & maven compiler properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@ See http://spdx.org for information on SPDX.
 # Goal Overview
 createSPDX creates an SPDX document for artifacts defined in the POM file.  Will replace any exsiting SPDX documents.
 
+# Code quality badges
+
+| Bugs        | Security Rating           | Maintainability  | Tech debt  |
+| ------------- |:-------------:| -----:|
+|   [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=spdx-maven-plugin&metric=bugs)](https://sonarcloud.io/dashboard?id=spdx-maven-plugin)    | [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-maven-plugin&metric=security_rating)](https://sonarcloud.io/dashboard?id=spdx-maven-plugin) | [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-maven-plugin&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=spdx-maven-plugin) | [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=spdx-maven-plugin&metric=sqale_index)](https://sonarcloud.io/dashboard?id=spdx-maven-plugin) |
+
+
+
+
+
 # Usage
 In the build plugins section add the plugin with a goal of createSPDX:
 ```xml
@@ -39,14 +49,14 @@ File level data supports default parameters which are applied to all files.
 
 File specific parameters can be specified in the configuration parameter pathsWithSpecificSpdxInfo which
 includes a directoryOrFile configuration parameter in addition to the SPDX file level
-parameters. 
+parameters.
 
 A mapping of POM properties and configuration parameters can be found in the spreadsheet
 SPDX-fields-maven-mapping.xlsx.
 
 The treatment of licenses for Maven is somewhat involved.  Where possible,
 SPDX standard licenses ID's should be used.  If no SPDX standard license
-is available, a nonStandardLicense must be declared as a parameter including 
+is available, a nonStandardLicense must be declared as a parameter including
 a unique license ID and the verbatim license text.
 
 # Example

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,8 @@
   </organization>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
   </properties>
   <licenses>
       <license>


### PR DESCRIPTION
Hi @goneall ,

I have added this to the property in the pom.xml. 

``` 
<properties>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   <maven.compiler.source>1.6</maven.compiler.source>
   <maven.compiler.target>1.6</maven.compiler.target>
</properties>
```

Additionally, I have created SPDX org on sonarcloud as well as created badges for this repo. 
Please let me know if you sonarcloud useful. I will add you as an admin for the org on sonarcloud once you sign-in with your github account at https://sonarcloud.io/