### PR TITLE
Use `groupId` and `artifactId` for naming SPDX files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,14 @@
-SPDX Maven Plugin is a plugin to Maven which produces Software Package Data Exchange (SPDX) documents for artifacts described in the POM file.
-See http://spdx.org for information on SPDX.
+SPDX Maven Plugin is a plugin to Maven which produces [Software Package Data Exchange (SPDX)](https://spdx.dev/) documents for artifacts described in the POM file.
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.spdx/spdx-maven-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.spdx/spdx-maven-plugin)
 
 # Goal Overview
-createSPDX creates an SPDX document for artifacts defined in the POM file.  Will replace any exsiting SPDX documents.
+
+`spdx:createSPDX` creates an SPDX document for artifacts defined in the POM file. It will replace any existing SPDX documents.
 
 # Code quality badges
 
 |   [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=spdx-maven-plugin&metric=bugs)](https://sonarcloud.io/dashboard?id=spdx-maven-plugin)    | [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-maven-plugin&metric=security_rating)](https://sonarcloud.io/dashboard?id=spdx-maven-plugin) | [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-maven-plugin&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=spdx-maven-plugin) | [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=spdx-maven-plugin&metric=sqale_index)](https://sonarcloud.io/dashboard?id=spdx-maven-plugin) |
-
-
-
-
 
 # Usage
 In the build plugins section add the plugin with a goal of createSPDX:
@@ -39,30 +35,30 @@ In the build plugins section add the plugin with a goal of createSPDX:
                 </plugin>
 ```
 
-Then invoke with *mvn spdx:createSPDX* and your spdx file will be generated in *target/site/{artifactId}-{version}.spdx*.
+Then invoke with `mvn spdx:createSPDX` and your SPDX file will be generated in `./target/site/{groupId}_{artifactId}-{version}.spdx`.
 
 # Additional Configuration
 
-All SPDX document and SPDX package properties are supported.  Some of the properties
+All SPDX document and SPDX package properties are supported.  Some properties
 are taken from existing POM properties while others are specified in the configuration
 section.
 
 File level data supports default parameters which are applied to all files.
 
-File specific parameters can be specified in the configuration parameter pathsWithSpecificSpdxInfo which
-includes a directoryOrFile configuration parameter in addition to the SPDX file level
+File specific parameters can be specified in the configuration parameter `pathsWithSpecificSpdxInfo` which
+includes a `directoryOrFile` configuration parameter in addition to the SPDX file level
 parameters.
 
 A mapping of POM properties and configuration parameters can be found in the spreadsheet
-SPDX-fields-maven-mapping.xlsx.
+[`SPDX-fields-maven-mapping.xlsx`](SPDX-fields-maven-mapping.xlsx).
 
 The treatment of licenses for Maven is somewhat involved.  Where possible,
 SPDX standard licenses ID's should be used.  If no SPDX standard license
-is available, a nonStandardLicense must be declared as a parameter including
+is available, a `nonStandardLicense` must be declared as a parameter including
 a unique license ID and the verbatim license text.
 
 # Example
-See the file SpdxTools-POM-File-Example.xml for an example project using the spdx-maven-plugin.
+See the file [`SpdxTools-POM-File-Example.xml`](SpdxTools-POM-File-Example.xml) for an example project using the spdx-maven-plugin.
 
 # Contributing
 See the [CONTRIBUTING.MD](CONTRIBUTING.md) documentation.

--- a/src/main/java/org/spdx/maven/CreateSpdxMojo.java
+++ b/src/main/java/org/spdx/maven/CreateSpdxMojo.java
@@ -118,7 +118,7 @@ public class CreateSpdxMojo extends AbstractMojo
     /**
      * SPDX File name
      */
-    @Parameter( defaultValue = "${project.reporting.outputDirectory}/${project.name}-${project.version}.spdx.rdf.xml",
+    @Parameter( defaultValue = "${project.reporting.outputDirectory}/${project.groupId}_${project.artifactId}-${project.version}.spdx.rdf.xml",
                 property = "spdxFileName",
                 required = true )
     private File spdxFile;
@@ -126,7 +126,7 @@ public class CreateSpdxMojo extends AbstractMojo
     /**
      * Document namespace - must be unique for the artifact and SPDX file
      */
-    @Parameter( defaultValue = "http://spdx.org/spdxpackages/${project.name}-${project.version}",
+    @Parameter( defaultValue = "http://spdx.org/spdxpackages/${project.groupId}_${project.artifactId}-${project.version}",
                 property = "spdxDocumentNamespace",
                 required = true )
     private String spdxDocumentNamespace;
@@ -483,7 +483,7 @@ public class CreateSpdxMojo extends AbstractMojo
      * Collect dependency information from Maven dependencies
      *
      * @param dependencies Maven dependencies
-     * @param session2
+     * @param licenseManager
      * @return information collected from Maven dependencies
      * @throws LicenseMapperException
      */


### PR DESCRIPTION
The `project.name` property in Maven contains a human-readable name of the artifact:

> `name`: Projects tend to have conversational names, beyond the `artifactId`. The Sun engineers did not refer to their project as "java-1.5", but rather just called it "Tiger". Here is where to set that value.

Source: name: https://maven.apache.org/pom.html#more-project-information

For automatically created filenames, `artifactId` in combination with `groupId` would be a better alternative.

Closes https://github.com/spdx/spdx-maven-plugin/issues/8