### PR TITLE
Update github workflow to only run Sonar when key exists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,4 +38,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar
+      run: |
+        if [[ $SONAR_TOKEN != "" ]]; then
+           mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent install sonar:sonar
+        else
+           mvn --batch-mode --update-snapshots verify
+        fi


### PR DESCRIPTION
This resolves a github action failure for pull requests made outside
the SPDX repo (e.g. from forks)

Signed-off-by: Gary O'Neall <gary@sourceauditor.com>