### PR TITLE
Use the maven-enforcer-plugin to enforce the use of Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,26 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <id>enforce-java</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>${maven.compiler.release}</version>
+                </requireJavaVersion>
+              </rules>    
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>		
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
 		<artifactId>maven-compiler-plugin</artifactId>
 		<version>3.6.1</version>
       </plugin>


### PR DESCRIPTION
This allows the build to fail fast instead of getting a class version exception later.