### PR TITLE
Don't fork execution of createSPDX

### DIFF
--- a/src/main/java/org/spdx/maven/CreateSpdxMojo.java
+++ b/src/main/java/org/spdx/maven/CreateSpdxMojo.java
@@ -83,8 +83,6 @@ import java.util.Set;
 @Mojo( name = "createSPDX",
        defaultPhase = LifecyclePhase.VERIFY,
        requiresDependencyResolution = ResolutionScope.TEST )
-@Execute( goal = "createSPDX",
-          phase = LifecyclePhase.VERIFY )
 public class CreateSpdxMojo extends AbstractMojo
 {
     static final String INCLUDE_ALL = "**/*";


### PR DESCRIPTION
This causes portions of builds to be re-run unnecessarily, for example, see the discussion in https://github.com/apache/commons-csv/pull/306