### PR TITLE
Use URI instead of URL for document namespace

### DIFF
--- a/src/main/java/org/spdx/maven/CreateSpdxMojo.java
+++ b/src/main/java/org/spdx/maven/CreateSpdxMojo.java
@@ -1,5 +1,7 @@
 package org.spdx.maven;
 
+import org.apache.commons.lang3.StringUtils;
+
 /*
  * Copyright 2014 Source Auditor Inc.
  *
@@ -25,7 +27,6 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 
 import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -49,7 +50,6 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -446,11 +446,8 @@ public class CreateSpdxMojo extends AbstractMojo
         SpdxDocumentBuilder builder;
         try
         {
-            URL namespaceUrl = new URL( spdxDocumentNamespace );
-            URI uri = new URI( namespaceUrl.getProtocol(), namespaceUrl.getUserInfo(), namespaceUrl.getHost(),
-                    namespaceUrl.getPort(), namespaceUrl.getPath(), namespaceUrl.getQuery(), namespaceUrl.getRef() );
-            namespaceUrl = uri.toURL();
-            builder = new SpdxDocumentBuilder( this.getLog(), spdxFile, namespaceUrl,
+            URI namespaceUri = new URI( spdxDocumentNamespace );
+            builder = new SpdxDocumentBuilder( this.getLog(), spdxFile, namespaceUri,
                     this.matchLicensesOnCrossReferenceUrls, outputFormat );
         }
         catch ( SpdxBuilderException e )
@@ -465,11 +462,11 @@ public class CreateSpdxMojo extends AbstractMojo
                     "License mapping error creating SPDX Document Builder: " + e.getMessage(), e ) );
 
         }
-        catch ( MalformedURLException | URISyntaxException e )
+        catch ( URISyntaxException e )
         {
-            this.getLog().error( "Invalid SPDX document namespace - not a valid URL: " + spdxDocumentNamespace, e );
+            this.getLog().error( "Invalid SPDX document namespace - not a valid URI: " + spdxDocumentNamespace, e );
             throw ( new MojoExecutionException(
-                    "Invalid SPDX document namespace - not a valid URL: " + spdxDocumentNamespace, e ) );
+                    "Invalid SPDX document namespace - not a valid URI: " + spdxDocumentNamespace, e ) );
         }
         if ( nonStandardLicenses != null )
         {

--- a/src/main/java/org/spdx/maven/CreateSpdxMojo.java
+++ b/src/main/java/org/spdx/maven/CreateSpdxMojo.java
@@ -1,7 +1,5 @@
 package org.spdx.maven;
 
-import org.apache.commons.lang3.StringUtils;
-
 /*
  * Copyright 2014 Source Auditor Inc.
  *
@@ -47,9 +45,9 @@ import org.spdx.library.model.license.LicenseInfoFactory;
 import org.spdx.library.model.license.SpdxNoAssertionLicense;
 
 import java.io.File;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -380,6 +378,7 @@ public class CreateSpdxMojo extends AbstractMojo
     
     private String artifactType;
 
+    @SuppressWarnings( "deprecation" )
     public void execute() throws MojoExecutionException
     {
         if ( includeTransitiveDependencies )
@@ -446,6 +445,10 @@ public class CreateSpdxMojo extends AbstractMojo
         SpdxDocumentBuilder builder;
         try
         {
+            if ( spdxDocumentNamespace.startsWith( "http://spdx.org/spdxpackages/" )) {
+                // Fix up any URI encoding issues with the default
+                spdxDocumentNamespace = spdxDocumentNamespace.replace( " ", "%20" );
+            }
             URI namespaceUri = new URI( spdxDocumentNamespace );
             builder = new SpdxDocumentBuilder( this.getLog(), spdxFile, namespaceUri,
                     this.matchLicensesOnCrossReferenceUrls, outputFormat );

--- a/src/main/java/org/spdx/maven/SpdxDocumentBuilder.java
+++ b/src/main/java/org/spdx/maven/SpdxDocumentBuilder.java
@@ -19,7 +19,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import java.security.NoSuchAlgorithmException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -93,7 +93,7 @@ public class SpdxDocumentBuilder
      * @throws SpdxBuilderException
      * @throws LicenseMapperException
      */
-    public SpdxDocumentBuilder( Log log, File spdxFile, URL spdxDocumentNamespace, 
+    public SpdxDocumentBuilder( Log log, File spdxFile, URI spdxDocumentNamespace, 
                                 boolean useStdLicenseSourceUrls, String outputFormat ) throws SpdxBuilderException, LicenseMapperException
     {
         this.log = log;

--- a/src/test/java/org/spdx/maven/TestSpdxMojo.java
+++ b/src/test/java/org/spdx/maven/TestSpdxMojo.java
@@ -93,7 +93,7 @@ public class TestSpdxMojo extends AbstractMojoTestCase
             assertEquals( 0, warnings.size() );
             // Test configuration parameters found in the test resources pom.xml file
             // Document namespace
-            assertEquals( "http://spdx.org/documents/spdx%20toolsv2.0%20rc1", result.getDocumentUri() );
+            assertEquals( "http://spdx.org/spdxpackages/spdx%20toolsv2.0%20rc1", result.getDocumentUri() );
             // Non-standard licenses
             ExtractedLicenseInfo[] licenseInfos = result.getExtractedLicenseInfos().toArray( new ExtractedLicenseInfo[result.getExtractedLicenseInfos().size()] );
             assertEquals( 2, licenseInfos.length );

--- a/src/test/resources/unit/spdx-maven-plugin-test/pom-with-no-contributors.xml
+++ b/src/test/resources/unit/spdx-maven-plugin-test/pom-with-no-contributors.xml
@@ -103,7 +103,7 @@
                     <projectHelper implementation="org.spdx.maven.stubs.MavenProjectHelperStub"/>
                     <spdxFile>src/test/resources/unit/spdx-maven-plugin-test/test.spdx.rdf.xml</spdxFile>
                     <outputFormat>RDF/XML</outputFormat>
-                    <spdxDocumentNamespace>http://spdx.org/documents/spdx toolsv2.0 rc1</spdxDocumentNamespace>
+                    <spdxDocumentNamespace>http://spdx.org/documents/spdx%20toolsv2.0%20rc1</spdxDocumentNamespace>
                     <documentComment>Document Comment</documentComment>
                     <documentAnnotations>
                         <param>

--- a/src/test/resources/unit/spdx-maven-plugin-test/pom.xml
+++ b/src/test/resources/unit/spdx-maven-plugin-test/pom.xml
@@ -103,7 +103,7 @@
                     <projectHelper implementation="org.spdx.maven.stubs.MavenProjectHelperStub"/>
                     <spdxFile>src/test/resources/unit/spdx-maven-plugin-test/test.spdx.rdf.xml</spdxFile>
                     <outputFormat>RDF/XML</outputFormat>
-                    <spdxDocumentNamespace>http://spdx.org/documents/spdx%20toolsv2.0%20rc1</spdxDocumentNamespace>
+                    <spdxDocumentNamespace>http://spdx.org/spdxpackages/spdx toolsv2.0 rc1</spdxDocumentNamespace>
                     <documentComment>Document Comment</documentComment>
                     <documentAnnotations>
                         <param>

--- a/src/test/resources/unit/spdx-maven-plugin-test/pom.xml
+++ b/src/test/resources/unit/spdx-maven-plugin-test/pom.xml
@@ -103,7 +103,7 @@
                     <projectHelper implementation="org.spdx.maven.stubs.MavenProjectHelperStub"/>
                     <spdxFile>src/test/resources/unit/spdx-maven-plugin-test/test.spdx.rdf.xml</spdxFile>
                     <outputFormat>RDF/XML</outputFormat>
-                    <spdxDocumentNamespace>http://spdx.org/documents/spdx toolsv2.0 rc1</spdxDocumentNamespace>
+                    <spdxDocumentNamespace>http://spdx.org/documents/spdx%20toolsv2.0%20rc1</spdxDocumentNamespace>
                     <documentComment>Document Comment</documentComment>
                     <documentAnnotations>
                         <param>

--- a/src/test/resources/unit/spdx-maven-plugin-test/uri-pom.xml
+++ b/src/test/resources/unit/spdx-maven-plugin-test/uri-pom.xml
@@ -31,6 +31,11 @@
       <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
+	<dependency>
+  	  <groupId>org.spdx</groupId>
+  	  <artifactId>java-spdx-library</artifactId>
+  	  <version>1.1.0</version>
+  	</dependency>
   </dependencies>
 
     <build>
@@ -96,9 +101,9 @@
                                         <!-- The defined stubs -->
                     <mavenProject implementation="org.spdx.maven.stubs.CreateSpdxMavenProjectStub"/>
                     <projectHelper implementation="org.spdx.maven.stubs.MavenProjectHelperStub"/>
-                    <spdxFile>src/test/resources/unit/spdx-maven-plugin-test/test.spdx.json</spdxFile>
-                    <outputFormat>JSON</outputFormat>
-                    <spdxDocumentNamespace>http://spdx.org/documents/spdx%20toolsv2.0%20rc1</spdxDocumentNamespace>
+                    <spdxFile>src/test/resources/unit/spdx-maven-plugin-test/test.spdx.rdf.xml</spdxFile>
+                    <outputFormat>RDF/XML</outputFormat>
+                    <spdxDocumentNamespace>spdx://sbom.foobar.dev/2.3/test-package-1.1.0</spdxDocumentNamespace>
                     <documentComment>Document Comment</documentComment>
                     <documentAnnotations>
                         <param>


### PR DESCRIPTION
Fixes #82

Note: This commit removes escaping of the namespace for the URI This may cause an incompatibility for some applications