### PR TITLE
Fix dependency issue

### DIFF
--- a/src/main/java/org/spdx/maven/SpdxDependencyInformation.java
+++ b/src/main/java/org/spdx/maven/SpdxDependencyInformation.java
@@ -313,7 +313,6 @@ public class SpdxDependencyInformation
         try
         {
             ProjectBuildingRequest request = new DefaultProjectBuildingRequest( session.getProjectBuildingRequest() );
-            request.setProject( mavenProject );
             request.setRemoteRepositories( mavenProject.getRemoteArtifactRepositories() );
             for (ArtifactRepository ar:request.getRemoteRepositories()) {
                 log.debug( "request Remote repository ID: " + ar.getId() );


### PR DESCRIPTION
This issue was introduced with PR #85.  The dependency project was set to the top level project and not to the dependency project leading to the dependency information getting lost.