### PR TITLE
use Maven convention for list content

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In the build plugins section add the plugin with a goal of createSPDX:
                     </executions>
                     <configuration>
                       <excludedFilePatterns>
-                        <param>*.spdx</param>
+                        <excludedFilePattern>*.spdx</excludedFilePattern>
                       </excludedFilePatterns>
                       <!-- See documentation below for additional configuration -->
                     </configuration>

--- a/src/test/resources/unit/app-bomination/pom.xml
+++ b/src/test/resources/unit/app-bomination/pom.xml
@@ -79,7 +79,7 @@
               <spdxDocumentNamespace>http://spdx.org/documents/APP-BOM-Ination-3d81ad36-2ee1-45be-85b6-83eba529424c</spdxDocumentNamespace>
               <documentComment>This document is an example of an SPDX 2.1 file created by the SPDX Maven plugin</documentComment>
               <nonStandardLicenses>
-                  <param>
+                  <nonStandardLicense>
                       <licenseId>LicenseRef-FaustProprietary</licenseId>
                       <extractedText>FAUST, INC. PROPRIETARY LICENSE:
 
@@ -94,11 +94,11 @@ Copyright (C) 2016 Faust Inc. All, and I mean ALL, rights are reserved.
                       </extractedText>
                       <name>Faust (really) Proprietary License</name>
                       <comment>This license was extracted from the file InsufficientKarmaException</comment>
-                  </param>
+                  </nonStandardLicense>
               </nonStandardLicenses>
               <defaultFileCopyright>NOASSERTION</defaultFileCopyright>
               <defaultFileContributors>
-                  <param>yevster</param>
+                  <defaultFileContributor>yevster</defaultFileContributor>
               </defaultFileContributors>
               <defaultLicenseInformationInFile>Apache-2.0</defaultLicenseInformationInFile>
               <defaultFileConcludedLicense>Apache-2.0</defaultFileConcludedLicense>
@@ -107,8 +107,8 @@ Copyright (C) 2016 Faust Inc. All, and I mean ALL, rights are reserved.
               <licenseConcluded>Apache-2.0 AND LicenseRef-FaustProprietary</licenseConcluded>
               <creatorComment>Created for the SPDX 2.1 BakeOff - wish I could be there in Berlin!</creatorComment>
               <creators>
-                  <param>Person: Gary O'Neall</param>
-                  <param>Organization: Source Auditor Inc.</param>
+                  <creator>Person: Gary O'Neall</creator>
+                  <creator>Organization: Source Auditor Inc.</creator>
               </creators>
               <copyrightText>Copyright (c) 2016 Faust, Inc.,</copyrightText>
               <pathsWithSpecificSpdxInfo>

--- a/src/test/resources/unit/spdx-maven-plugin-test/json-pom.xml
+++ b/src/test/resources/unit/spdx-maven-plugin-test/json-pom.xml
@@ -101,53 +101,53 @@
                     <spdxDocumentNamespace>http://spdx.org/documents/spdx%20toolsv2.0%20rc1</spdxDocumentNamespace>
                     <documentComment>Document Comment</documentComment>
                     <documentAnnotations>
-                        <param>
+                        <documentAnnotation>
                             <annotationComment>Annotation1</annotationComment>
                             <annotationType>REVIEW</annotationType>
                             <annotationDate>2010-01-29T18:30:22Z</annotationDate>
                             <annotator>Person:Test Person</annotator>
-                        </param>
-                        <param>
+                        </documentAnnotation>
+                        <documentAnnotation>
                             <annotationComment>Annotation2</annotationComment>
                             <annotationType>OTHER</annotationType>
                             <annotationDate>2012-11-29T18:30:22Z</annotationDate>
                             <annotator>Organization:Test Organization</annotator>
-                        </param>
+                        </documentAnnotation>
                     </documentAnnotations>
                     <packageAnnotations>
-                        <param>
+                        <packageAnnotation>
                             <annotationComment>PackageAnnotation</annotationComment>
                             <annotationType>REVIEW</annotationType>
                             <annotationDate>2015-01-29T18:30:22Z</annotationDate>
                             <annotator>Person:Test Package Person</annotator>
-                        </param>
+                        </packageAnnotation>
                     </packageAnnotations>
                     <nonStandardLicenses>
-                        <param>
+                        <nonStandardLicense>
                             <licenseId>LicenseRef-testLicense</licenseId>
                             <extractedText>Test license text</extractedText>
                             <name>Test License</name>
                             <crossReference>
-                                <param>http://www.test.url/testLicense.html</param>
+                                <crossReference>http://www.test.url/testLicense.html</crossReference>
                             </crossReference>
                             <comment>Test license comment</comment>
-                        </param>
-                        <param>
+                        </nonStandardLicense>
+                        <nonStandardLicense>
                             <licenseId>LicenseRef-testLicense2</licenseId>
                             <extractedText>Second est license text</extractedText>
                             <name>Second Test License</name>
                             <crossReference>
-                                <param>http://www.test.url/testLicense2.html</param>
-                                <param>http://www.test.url/testLicense2-alt.html</param>
+                                <crossReference>http://www.test.url/testLicense2.html</crossReference>
+                                <crossReference>http://www.test.url/testLicense2-alt.html</crossReference>
                             </crossReference>
                             <comment>Second Test license comment</comment>
-                        </param>
+                        </nonStandardLicense>
                     </nonStandardLicenses>
                     <defaultFileCopyright>Copyright (c) 2012, 2013, 2014 Source Auditor Inc.</defaultFileCopyright>
                     <defaultFileComment>Default file comment</defaultFileComment>
                     <defaultFileContributors>
-                        <param>First contributor</param>
-                        <param>Second contributor</param>
+                        <defaultFileContributor>First contributor</defaultFileContributor>
+                        <defaultFileContributor>Second contributor</defaultFileContributor>
                     </defaultFileContributors>
                     <defaultLicenseInformationInFile>Apache-1.1</defaultLicenseInformationInFile>
                     <defaultFileConcludedLicense>Apache-2.0</defaultFileConcludedLicense>
@@ -157,8 +157,8 @@
                     <licenseConcluded>BSD-3-Clause</licenseConcluded>
                     <creatorComment>Creator comment</creatorComment>
                     <creators>
-                        <param>Person: Creator1</param>
-                        <param>Person: Creator2</param>
+                        <creator>Person: Creator1</creator>
+                        <creator>Person: Creator2</creator>
                     </creators>
                     <licenseComments>License comments</licenseComments>
                     <originator>Organization: Originating org.</originator>
@@ -199,7 +199,7 @@
                             <directoryOrFile>src/main/java/CommonCode.java</directoryOrFile>
                             <fileComment>Comment for CommonCode</fileComment>
                             <fileContributors>
-                                <param>Contributor to CommonCode</param>
+                                <fileContributor>Contributor to CommonCode</fileContributor>
                             </fileContributors>
                             <fileCopyright>Common Code Copyright</fileCopyright>
                             <fileLicenseComment>License Comment for Common Code</fileLicenseComment>

--- a/src/test/resources/unit/spdx-maven-plugin-test/pom-with-no-contributors.xml
+++ b/src/test/resources/unit/spdx-maven-plugin-test/pom-with-no-contributors.xml
@@ -106,47 +106,47 @@
                     <spdxDocumentNamespace>http://spdx.org/documents/spdx%20toolsv2.0%20rc1</spdxDocumentNamespace>
                     <documentComment>Document Comment</documentComment>
                     <documentAnnotations>
-                        <param>
+                        <documentAnnotation>
                             <annotationComment>Annotation1</annotationComment>
                             <annotationType>REVIEW</annotationType>
                             <annotationDate>2010-01-29T18:30:22Z</annotationDate>
                             <annotator>Person:Test Person</annotator>
-                        </param>
-                        <param>
+                        </documentAnnotation>
+                        <documentAnnotation>
                             <annotationComment>Annotation2</annotationComment>
                             <annotationType>OTHER</annotationType>
                             <annotationDate>2012-11-29T18:30:22Z</annotationDate>
                             <annotator>Organization:Test Organization</annotator>
-                        </param>
+                        </documentAnnotation>
                     </documentAnnotations>
                     <packageAnnotations>
-                        <param>
+                        <packageAnnotation>
                             <annotationComment>PackageAnnotation</annotationComment>
                             <annotationType>REVIEW</annotationType>
                             <annotationDate>2015-01-29T18:30:22Z</annotationDate>
                             <annotator>Person:Test Package Person</annotator>
-                        </param>
+                        </packageAnnotation>
                     </packageAnnotations>
                     <nonStandardLicenses>
-                        <param>
+                        <nonStandardLicense>
                             <licenseId>LicenseRef-testLicense</licenseId>
                             <extractedText>Test license text</extractedText>
                             <name>Test License</name>
                             <crossReference>
-                                <param>http://www.test.url/testLicense.html</param>
+                                <crossReference>http://www.test.url/testLicense.html</crossReference>
                             </crossReference>
                             <comment>Test license comment</comment>
-                        </param>
-                        <param>
+                        </nonStandardLicense>
+                        <nonStandardLicense>
                             <licenseId>LicenseRef-testLicense2</licenseId>
                             <extractedText>Second est license text</extractedText>
                             <name>Second Test License</name>
                             <crossReference>
-                                <param>http://www.test.url/testLicense2.html</param>
-                                <param>http://www.test.url/testLicense2-alt.html</param>
+                                <crossReference>http://www.test.url/testLicense2.html</crossReference>
+                                <crossReference>http://www.test.url/testLicense2-alt.html</crossReference>
                             </crossReference>
                             <comment>Second Test license comment</comment>
-                        </param>
+                        </nonStandardLicense>
                     </nonStandardLicenses>
                     <defaultFileCopyright>Copyright (c) 2012, 2013, 2014 Source Auditor Inc.</defaultFileCopyright>
                     <defaultFileComment>Default file comment</defaultFileComment>
@@ -158,8 +158,8 @@
                     <licenseConcluded>BSD-3-Clause</licenseConcluded>
                     <creatorComment>Creator comment</creatorComment>
                     <creators>
-                        <param>Person: Creator1</param>
-                        <param>Person: Creator2</param>
+                        <creator>Person: Creator1</creator>
+                        <creator>Person: Creator2</creator>
                     </creators>
                     <licenseComments>License comments</licenseComments>
                     <originator>Organization: Originating org.</originator>
@@ -200,7 +200,7 @@
                             <directoryOrFile>src/main/java/CommonCode.java</directoryOrFile>
                             <fileComment>Comment for CommonCode</fileComment>
                             <fileContributors>
-                                <param>Contributor to CommonCode</param>
+                                <fileContributor>Contributor to CommonCode</fileContributor>
                             </fileContributors>
                             <fileCopyright>Common Code Copyright</fileCopyright>
                             <fileLicenseComment>License Comment for Common Code</fileLicenseComment>

--- a/src/test/resources/unit/spdx-maven-plugin-test/pom.xml
+++ b/src/test/resources/unit/spdx-maven-plugin-test/pom.xml
@@ -106,53 +106,53 @@
                     <spdxDocumentNamespace>http://spdx.org/spdxpackages/spdx toolsv2.0 rc1</spdxDocumentNamespace>
                     <documentComment>Document Comment</documentComment>
                     <documentAnnotations>
-                        <param>
+                        <documentAnnotation>
                             <annotationComment>Annotation1</annotationComment>
                             <annotationType>REVIEW</annotationType>
                             <annotationDate>2010-01-29T18:30:22Z</annotationDate>
                             <annotator>Person:Test Person</annotator>
-                        </param>
-                        <param>
+                        </documentAnnotation>
+                        <documentAnnotation>
                             <annotationComment>Annotation2</annotationComment>
                             <annotationType>OTHER</annotationType>
                             <annotationDate>2012-11-29T18:30:22Z</annotationDate>
                             <annotator>Organization:Test Organization</annotator>
-                        </param>
+                        </documentAnnotation>
                     </documentAnnotations>
                     <packageAnnotations>
-                        <param>
+                        <packageAnnotation>
                             <annotationComment>PackageAnnotation</annotationComment>
                             <annotationType>REVIEW</annotationType>
                             <annotationDate>2015-01-29T18:30:22Z</annotationDate>
                             <annotator>Person:Test Package Person</annotator>
-                        </param>
+                        </packageAnnotation>
                     </packageAnnotations>
                     <nonStandardLicenses>
-                        <param>
+                        <nonStandardLicense>
                             <licenseId>LicenseRef-testLicense</licenseId>
                             <extractedText>Test license text</extractedText>
                             <name>Test License</name>
                             <crossReference>
-                                <param>http://www.test.url/testLicense.html</param>
+                                <crossReference>http://www.test.url/testLicense.html</crossReference>
                             </crossReference>
                             <comment>Test license comment</comment>
-                        </param>
-                        <param>
+                        </nonStandardLicense>
+                        <nonStandardLicense>
                             <licenseId>LicenseRef-testLicense2</licenseId>
                             <extractedText>Second est license text</extractedText>
                             <name>Second Test License</name>
                             <crossReference>
-                                <param>http://www.test.url/testLicense2.html</param>
-                                <param>http://www.test.url/testLicense2-alt.html</param>
+                                <crossReference>http://www.test.url/testLicense2.html</crossReference>
+                                <crossReference>http://www.test.url/testLicense2-alt.html</crossReference>
                             </crossReference>
                             <comment>Second Test license comment</comment>
-                        </param>
+                        </nonStandardLicense>
                     </nonStandardLicenses>
                     <defaultFileCopyright>Copyright (c) 2012, 2013, 2014 Source Auditor Inc.</defaultFileCopyright>
                     <defaultFileComment>Default file comment</defaultFileComment>
                     <defaultFileContributors>
-                        <param>First contributor</param>
-                        <param>Second contributor</param>
+                        <defaultFileContributor>First contributor</defaultFileContributor>
+                        <defaultFileContributor>Second contributor</defaultFileContributor>
                     </defaultFileContributors>
                     <defaultLicenseInformationInFile>Apache-1.1</defaultLicenseInformationInFile>
                     <defaultFileConcludedLicense>Apache-2.0</defaultFileConcludedLicense>
@@ -162,8 +162,8 @@
                     <licenseConcluded>BSD-3-Clause</licenseConcluded>
                     <creatorComment>Creator comment</creatorComment>
                     <creators>
-                        <param>Person: Creator1</param>
-                        <param>Person: Creator2</param>
+                        <creator>Person: Creator1</creator>
+                        <creator>Person: Creator2</creator>
                     </creators>
                     <licenseComments>License comments</licenseComments>
                     <originator>Organization: Originating org.</originator>
@@ -204,7 +204,7 @@
                             <directoryOrFile>src/main/java/CommonCode.java</directoryOrFile>
                             <fileComment>Comment for CommonCode</fileComment>
                             <fileContributors>
-                                <param>Contributor to CommonCode</param>
+                                <fileContributor>Contributor to CommonCode</fileContributor>
                             </fileContributors>
                             <fileCopyright>Common Code Copyright</fileCopyright>
                             <fileLicenseComment>License Comment for Common Code</fileLicenseComment>

--- a/src/test/resources/unit/spdx-maven-plugin-test/spdx-pom.xml
+++ b/src/test/resources/unit/spdx-maven-plugin-test/spdx-pom.xml
@@ -198,23 +198,23 @@
 						<defaultFileComment>test file comment</defaultFileComment>
 						<testParameter>test parm</testParameter>
 						<documentAnnotations>
-							<param>
+							<documentAnnotation>
 								<annotator>Person: Gary O'Neall</annotator>
 								<annotationDate> 2015-07-23T18:30:22Z</annotationDate>
 								<annotationType>OTHER</annotationType>
 								<annotationComment>Initial submission for the SPDX 2.0 document bake-off</annotationComment>
-							</param>
+							</documentAnnotation>
 						</documentAnnotations>
 						<packageAnnotations>
-							<param>
+							<packageAnnotation>
 								<annotator>Person: Gary O'Neall</annotator>
 								<annotationDate> 2015-07-23T18:30:22Z</annotationDate>
 								<annotationType>OTHER</annotationType>
 								<annotationComment>SPDX Tools package submitted for the SPDX 2.0 bake-off</annotationComment>
-							</param>
+							</packageAnnotation>
 						</packageAnnotations>
 						<nonStandardLicenses>
-							<param>
+							<nonStandardLicense>
 								<licenseId>LicenseRef-CyberNeko</licenseId>
 								<extractedText>The CyberNeko Software License, Version 1.0
 
@@ -264,11 +264,11 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 This license is based on the Apache Software License, version 1.1.</extractedText>
 							<name>The CyberNeko Software License, Version 1.0</name>
-						</param>
+						</nonStandardLicense>
 					</nonStandardLicenses>
 					<defaultFileCopyright>Copyright (c) 2012, 2013, 2014, 2015 Source Auditor Inc.</defaultFileCopyright>
 					<defaultFileContributors>
-						<param>Gary O'Neall</param>
+						<defaultFileContributor>Gary O'Neall</defaultFileContributor>
 					</defaultFileContributors>
 					<defaultLicenseInformationInFile>Apache-2.0</defaultLicenseInformationInFile>
 					<defaultFileConcludedLicense>Apache-2.0</defaultFileConcludedLicense>
@@ -287,7 +287,7 @@ This license is based on the Apache Software License, version 1.1.</extractedTex
 					<licenseConcluded>(Apache-2.0 AND MIT AND LicenseRef-CyberNeko AND LGPL-2.1 AND BSD-3-Clause AND X11 AND MPL-1.0)</licenseConcluded>
 						<creatorComment>Created for Linux Con. SPDX Bakeoff 2015</creatorComment>
 					<creators>
-						<param>Person: Gary O'Neall</param>
+					<creator>Person: Gary O'Neall</creator>
 					</creators>
 					<originator>Organization: Linux Foundation</originator>
 				</configuration>

--- a/src/test/resources/unit/spdx-maven-plugin-test/uri-pom.xml
+++ b/src/test/resources/unit/spdx-maven-plugin-test/uri-pom.xml
@@ -106,53 +106,53 @@
                     <spdxDocumentNamespace>spdx://sbom.foobar.dev/2.3/test-package-1.1.0</spdxDocumentNamespace>
                     <documentComment>Document Comment</documentComment>
                     <documentAnnotations>
-                        <param>
+                        <documentAnnotation>
                             <annotationComment>Annotation1</annotationComment>
                             <annotationType>REVIEW</annotationType>
                             <annotationDate>2010-01-29T18:30:22Z</annotationDate>
                             <annotator>Person:Test Person</annotator>
-                        </param>
-                        <param>
+                        </documentAnnotation>
+                        <documentAnnotation>
                             <annotationComment>Annotation2</annotationComment>
                             <annotationType>OTHER</annotationType>
                             <annotationDate>2012-11-29T18:30:22Z</annotationDate>
                             <annotator>Organization:Test Organization</annotator>
-                        </param>
+                        </documentAnnotation>
                     </documentAnnotations>
                     <packageAnnotations>
-                        <param>
+                        <packageAnnotation>
                             <annotationComment>PackageAnnotation</annotationComment>
                             <annotationType>REVIEW</annotationType>
                             <annotationDate>2015-01-29T18:30:22Z</annotationDate>
                             <annotator>Person:Test Package Person</annotator>
-                        </param>
+                        </packageAnnotation>
                     </packageAnnotations>
                     <nonStandardLicenses>
-                        <param>
+                        <nonStandardLicense>
                             <licenseId>LicenseRef-testLicense</licenseId>
                             <extractedText>Test license text</extractedText>
                             <name>Test License</name>
                             <crossReference>
-                                <param>http://www.test.url/testLicense.html</param>
+                                <crossReference>http://www.test.url/testLicense.html</crossReference>
                             </crossReference>
                             <comment>Test license comment</comment>
-                        </param>
-                        <param>
+                        </nonStandardLicense>
+                        <nonStandardLicense>
                             <licenseId>LicenseRef-testLicense2</licenseId>
                             <extractedText>Second est license text</extractedText>
                             <name>Second Test License</name>
                             <crossReference>
-                                <param>http://www.test.url/testLicense2.html</param>
-                                <param>http://www.test.url/testLicense2-alt.html</param>
+                                <crossReference>http://www.test.url/testLicense2.html</crossReference>
+                                <crossReference>http://www.test.url/testLicense2-alt.html</crossReference>
                             </crossReference>
                             <comment>Second Test license comment</comment>
-                        </param>
+                        </nonStandardLicense>
                     </nonStandardLicenses>
                     <defaultFileCopyright>Copyright (c) 2012, 2013, 2014 Source Auditor Inc.</defaultFileCopyright>
                     <defaultFileComment>Default file comment</defaultFileComment>
                     <defaultFileContributors>
-                        <param>First contributor</param>
-                        <param>Second contributor</param>
+                        <defaultFileContributor>First contributor</defaultFileContributor>
+                        <defaultFileContributor>Second contributor</defaultFileContributor>
                     </defaultFileContributors>
                     <defaultLicenseInformationInFile>Apache-1.1</defaultLicenseInformationInFile>
                     <defaultFileConcludedLicense>Apache-2.0</defaultFileConcludedLicense>
@@ -162,8 +162,8 @@
                     <licenseConcluded>BSD-3-Clause</licenseConcluded>
                     <creatorComment>Creator comment</creatorComment>
                     <creators>
-                        <param>Person: Creator1</param>
-                        <param>Person: Creator2</param>
+                        <creator>Person: Creator1</creator>
+                        <creator>Person: Creator2</creator>
                     </creators>
                     <licenseComments>License comments</licenseComments>
                     <originator>Organization: Originating org.</originator>
@@ -204,7 +204,7 @@
                             <directoryOrFile>src/main/java/CommonCode.java</directoryOrFile>
                             <fileComment>Comment for CommonCode</fileComment>
                             <fileContributors>
-                                <param>Contributor to CommonCode</param>
+                                <fileContributor>Contributor to CommonCode</fileContributor>
                             </fileContributors>
                             <fileCopyright>Common Code Copyright</fileCopyright>
                             <fileLicenseComment>License Comment for Common Code</fileLicenseComment>


### PR DESCRIPTION
while it is true that a goal parameter with list can use any XML element name, the convention is to use the singular of the parameter name: for a `excludedFilePatterns` parameter for example, `param` works but `excludedFilePattern` is what convention expects