### PR TITLE
consolidate sources from Maven project

### DIFF
--- a/src/main/java/org/spdx/maven/utils/SpdxDocumentBuilder.java
+++ b/src/main/java/org/spdx/maven/utils/SpdxDocumentBuilder.java
@@ -188,9 +188,7 @@ public class SpdxDocumentBuilder
     /**
      * Build the SPDX document from the files and save the information to the SPDX file
      *
-     * @param includedSourceDirectories   Source directories to be included in the document
-     * @param includedResourceDirectories Test directories to be included in the document
-     * @param includedTestDirectories     Resource directories to be included in the document
+     * @param sources                     Source directories to be included in the document
      * @param baseDir                     Base directory used to create the relative file paths for the SPDX file names
      * @param projectInformation          Project level SPDX information
      * @param defaultFileInformation      Default SPDX file information
@@ -200,9 +198,7 @@ public class SpdxDocumentBuilder
      * @param algorithms                  algorithms to use to generate checksums
      * @throws SpdxBuilderException
      */
-    public void buildDocumentFromFiles( FileSet[] includedSourceDirectories, 
-                                        FileSet[] includedTestDirectories, 
-                                        FileSet[] includedResourceDirectories, 
+    public void buildDocumentFromFiles( List<FileSet> sources,
                                         String baseDir, SpdxProjectInformation projectInformation, 
                                         SpdxDefaultFileInformation defaultFileInformation, 
                                         Map<String, SpdxDefaultFileInformation> pathSpecificInformation, 
@@ -214,7 +210,7 @@ public class SpdxDocumentBuilder
         {
             LOG.debug( "Starting buid document from files" );
             fillSpdxDocumentInformation( projectInformation );
-            collectSpdxFileInformation( includedSourceDirectories, includedTestDirectories, includedResourceDirectories,
+            collectSpdxFileInformation( sources,
                     baseDir, defaultFileInformation, spdxFile.getPath().replace( "\\", "/" ), pathSpecificInformation, algorithms );
             addDependencyInformation( dependencyInformation );
             modelStore.serialize( spdxDocumentNamespace, spdxOut );
@@ -519,9 +515,7 @@ public class SpdxDocumentBuilder
     /**
      * Collect information at the file level, fill in the SPDX document
      *
-     * @param includedSourceDirectories   Source directories to be included in the document
-     * @param includedResourceDirectories Test directories to be included in the document
-     * @param includedTestDirectories     Resource directories to be included in the document
+     * @param sources                     Source directories to be included in the document
      * @param baseDir                     project base directory used to construct the relative paths for the SPDX
      *                                    files
      * @param projectInformation          Project level SPDX information
@@ -532,7 +526,7 @@ public class SpdxDocumentBuilder
      * @throws InvalidSPDXAnalysisException
      * @throws SpdxBuilderException
      */
-    private void collectSpdxFileInformation( FileSet[] includedSourceDirectories, FileSet[] includedTestDirectories, FileSet[] includedResourceDirectories, 
+    private void collectSpdxFileInformation( List<FileSet> sources, 
                                              String baseDir, SpdxDefaultFileInformation defaultFileInformation, String spdxFileName, 
                                              Map<String, SpdxDefaultFileInformation> pathSpecificInformation, 
                                              Set<ChecksumAlgorithm> algorithms ) throws InvalidSPDXAnalysisException, SpdxBuilderException
@@ -540,12 +534,8 @@ public class SpdxDocumentBuilder
         SpdxFileCollector fileCollector = new SpdxFileCollector();
         try
         {
-            fileCollector.collectFiles( includedSourceDirectories, baseDir, defaultFileInformation,
+            fileCollector.collectFiles( sources, baseDir, defaultFileInformation,
                     pathSpecificInformation, projectPackage, RelationshipType.GENERATES, spdxDoc, algorithms );
-            fileCollector.collectFiles( includedTestDirectories, baseDir, defaultFileInformation,
-                    pathSpecificInformation, projectPackage, RelationshipType.TEST_CASE_OF, spdxDoc, algorithms );
-            fileCollector.collectFiles( includedResourceDirectories, baseDir, defaultFileInformation,
-                    pathSpecificInformation, projectPackage, RelationshipType.CONTAINED_BY, spdxDoc, algorithms );
         }
         catch ( SpdxCollectionException e )
         {

--- a/src/main/java/org/spdx/maven/utils/SpdxFileCollector.java
+++ b/src/main/java/org/spdx/maven/utils/SpdxFileCollector.java
@@ -161,7 +161,7 @@ public class SpdxFileCollector
      *
      * @throws SpdxCollectionException
      */
-    public void collectFiles( FileSet[] fileSets, String baseDir, 
+    public void collectFiles( List<FileSet> fileSets, String baseDir, 
                               SpdxDefaultFileInformation defaultFileInformation, 
                               Map<String, SpdxDefaultFileInformation> pathSpecificInformation, 
                               SpdxPackage projectPackage, RelationshipType relationshipType, 

--- a/src/test/java/org/spdx/maven/utils/TestSpdxFileCollector.java
+++ b/src/test/java/org/spdx/maven/utils/TestSpdxFileCollector.java
@@ -95,7 +95,7 @@ public class TestSpdxFileCollector
     private File directory;
     private String[] filePaths;
     private String[] SpdxFileNames;
-    private FileSet[] fileSets;
+    private List<FileSet> fileSets;
     private SpdxPackage spdxPackage;
     SpdxDocument spdxDoc = null;
 
@@ -172,7 +172,7 @@ public class TestSpdxFileCollector
         FileSet dirFileSet = new FileSet();
         dirFileSet.setDirectory( directory.getPath() );
         dirFileSet.setOutputDirectory( this.directory.getName() );
-        this.fileSets = new FileSet[] {dirFileSet};
+        this.fileSets = Arrays.asList( dirFileSet );
         this.spdxPackage = spdxDoc.createPackage( SpdxConstants.SPDX_ELEMENT_REF_PRENUM+"test", 
                                                   "TestPackage", 
                                                   concludedLicense, 
@@ -265,14 +265,14 @@ public class TestSpdxFileCollector
     public void testCollectFileInDirectoryPattern() throws SpdxCollectionException, InvalidSPDXAnalysisException
     {
         FileSet skipBin = new FileSet();
-        skipBin.setDirectory( this.fileSets[0].getDirectory() );
+        skipBin.setDirectory( this.fileSets.get(0).getDirectory() );
         skipBin.addExclude( "**/*.bin" );
-        skipBin.setOutputDirectory( this.fileSets[0].getOutputDirectory() );
+        skipBin.setOutputDirectory( this.fileSets.get(0).getOutputDirectory() );
         SpdxFileCollector collector = new SpdxFileCollector();
         SpdxFile[] SpdxFiles = collector.getFiles().toArray( new SpdxFile[collector.getFiles().size()] );
         assertEquals( 0, SpdxFiles.length );
 
-        collector.collectFiles( new FileSet[] {skipBin}, this.directory.getAbsolutePath(), this.defaultFileInformation,
+        collector.collectFiles( Arrays.asList( skipBin ), this.directory.getAbsolutePath(), this.defaultFileInformation,
                 new HashMap<>(), spdxPackage, RelationshipType.GENERATES, spdxDoc, sha1Algorithm );
         SpdxFiles = collector.getFiles().toArray( new SpdxFile[collector.getFiles().size()] );
         assertEquals( filePaths.length - 2, SpdxFiles.length );
@@ -522,7 +522,7 @@ public class TestSpdxFileCollector
             FileSet fileSet2 = new FileSet();
             fileSet2.setDirectory( tempDir2.getPath() );
 
-            collector.collectFiles( new FileSet[] {fileSet2}, tempDir2.getAbsolutePath(), info2, new HashMap<>(),
+            collector.collectFiles( Arrays.asList( fileSet2 ), tempDir2.getAbsolutePath(), info2, new HashMap<>(),
                     spdxPackage, RelationshipType.GENERATES, spdxDoc, sha1Algorithm );
             result = collector.getLicenseInfoFromFiles().toArray( new AnyLicenseInfo[collector.getLicenseInfoFromFiles().size()] );
             assertEquals( 3, result.length );


### PR DESCRIPTION
while doing that, I discovered that `getCompileSourceRoots()` was added twice: once in `getSourceDirectories()` and once in `getResourceDirectories()`