### PR TITLE
configure maven-release-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ buildNumber.properties
 .project
 .classpath
 .settings/
+.vscode/
 src/test/resources/unit/spdx-maven-plugin-test/spdx maven plugin test.spdx.rdf.xml
 
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
     <url>https://github.com/spdx/spdx-maven-plugin</url>
     <connection>scm:git:ssh://git@github.com:spdx/spdx-maven-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com:spdx/spdx-maven-plugin.git</developerConnection>
+    <tag>master</tag>
   </scm>
 
   <distributionManagement>
@@ -165,7 +166,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.11.0</version>
       </plugin>
       <plugin>
         <groupId>org.owasp</groupId>
@@ -198,20 +199,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-             <phase>verify</phase>
-             <goals>
-               <goal>jar-no-fork</goal>
-             </goals>
-           </execution>
-         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.3.0</version>
       </plugin>
@@ -237,6 +224,16 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
         <version>3.12.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>3.0.1</version>
+        <configuration>
+          <tagNameFormat>v@{project.version}</tagNameFormat>
+          <releaseProfiles>release</releaseProfiles>
+          <goals>deploy</goals>
+        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -335,13 +332,27 @@
       </build>
     </profile>
     <profile>
-      <id>gpg-signing</id>
+      <id>release</id>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.2.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>3.1.0</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>


### PR DESCRIPTION
releasing can then be done with `mvn release:prepare` followed by `mvn release:perform` (or in one shot `mvn release:prepare release:perform`)
Testing (without committing to Git) can be done using `-DdryRun` additional parameter, to see how the plugin behaves and does the final build from `target/checkout`.

full documentation is here https://maven.apache.org/maven-release/maven-release-plugin/index.html

this will avoid pollution from the IDE builds as seens in previous releases #122 
and update more useful fields in pom.xml than the minimum `<version>`