### PR TITLE
The attribute downloadLocation is null when no information cannot be retrieved

### DIFF
--- a/src/main/java/org/spdx/maven/utils/SpdxDependencyInformation.java
+++ b/src/main/java/org/spdx/maven/utils/SpdxDependencyInformation.java
@@ -360,6 +360,7 @@ public class SpdxDependencyInformation
                         .setComment( "This package was created for a Maven dependency.  No SPDX or license information could be found in the Maven POM file." )
                         .setVersionInfo( artifact.getBaseVersion() )
                         .setFilesAnalyzed( false )
+                        .setDownloadLocation( "NOASSERTION" )
                         .build();
         return pkg;
     }


### PR DESCRIPTION
# Type of change
- [ ] Added new project
- [X] Bug fix
- [ ] New features
- [ ] Enhanced documentation

# Changes proposed in this pull request

- ### Project name: #147

# Description
- [X] Maintain code format
- [ ] Unit test