### PR TITLE
Fix unit tests

### DIFF
--- a/src/test/java/org/spdx/maven/utils/TestMavenToSpdxLicenseMapper.java
+++ b/src/test/java/org/spdx/maven/utils/TestMavenToSpdxLicenseMapper.java
@@ -27,7 +27,7 @@ public class TestMavenToSpdxLicenseMapper
     private static final String APACHE2_URL = "http://www.apache.org/licenses/LICENSE-2.0";
     private static final String APACHE_SPDX_ID = "Apache-2.0";
 
-    private static final String MIT_URL = "http://opensource.org/licenses/MIT";
+    private static final String MIT_URL = "http://opensource.org/license/mit/";
     private static final String MIT_SPDX_ID = "MIT";
 
     SpdxDocument spdxDoc = null;


### PR DESCRIPTION
Some of the unit tests depend on external environment - the URL for one of the licenses changed in the license list which caused the unit tests to fail.  Also fixed the name of one of an indirect depency which apparently also changed.