### PR TITLE
Fix for inter-dependent maven modules forcing build.

### DIFF
--- a/src/main/java/org/spdx/maven/CreateSpdxMojo.java
+++ b/src/main/java/org/spdx/maven/CreateSpdxMojo.java
@@ -98,7 +98,7 @@ import java.util.Set;
  */
 @Mojo( name = "createSPDX",
        defaultPhase = LifecyclePhase.VERIFY,
-       requiresDependencyResolution = ResolutionScope.TEST )
+        requiresOnline = true )
 public class CreateSpdxMojo extends AbstractMojo
 {
     public static final String INCLUDE_ALL = "**/*";


### PR DESCRIPTION
Fix for issue https://github.com/spdx/spdx-maven-plugin/issues/158 .
In case of multi module inter dependent repo , pre-plugin step fails to resolve dependencies in case one module has dependency on other jars ( which will not be available until a complete build happens).
With this fix pre-plugin dependency will not fail for inter-dependent module jars. 