### PR TITLE
Bump the library to version 1.1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>org.spdx</groupId>
       <artifactId>java-spdx-library</artifactId>
-      <version>1.1.10</version>
+      <version>1.1.12</version>
     </dependency>
     <dependency>
       <groupId>org.spdx</groupId>


### PR DESCRIPTION
Fixes an issue with the license list version changing to x.y.z format