### PR TITLE
Adding an aggregateSpdx goal

### DIFF
--- a/src/it/advanced/pom.xml
+++ b/src/it/advanced/pom.xml
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/it/simple-aggregate-it/pom.xml
+++ b/src/it/simple-aggregate-it/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.spdx.it</groupId>
+  <artifactId>simple-aggregate-it</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>A simple IT verifying the basic use case.</description>
+  <packaging>pom</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>3.2.2</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <modules>
+    <module>../advanced</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>build-spdx</id>
+            <goals>
+              <goal>aggregateSPDX</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/simple-aggregate-it/src/main/java/simple/Simple.java
+++ b/src/it/simple-aggregate-it/src/main/java/simple/Simple.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014 Source Auditor Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package simple;
+
+public class Simple
+{
+    public static void main(String[] args)
+    {
+        System.out.println( "Hello World!");
+    }
+}

--- a/src/it/simple-aggregate-it/src/test/java/SimpleTest.java
+++ b/src/it/simple-aggregate-it/src/test/java/SimpleTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014 Source Auditor Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package simple;
+
+import org.junit.Test;
+
+public class SimpleTest
+{
+    @Test
+    public void test()
+    {
+
+    }
+}

--- a/src/it/simple-aggregate-it/verify.groovy
+++ b/src/it/simple-aggregate-it/verify.groovy
@@ -1,0 +1,3 @@
+File spdxFile = new File( basedir, "target/site/org.spdx.it_simple-aggregate-it-1.0-SNAPSHOT.spdx.json" );
+
+assert spdxFile.isFile()

--- a/src/main/java/org/spdx/maven/AggregateSpdxMojo.java
+++ b/src/main/java/org/spdx/maven/AggregateSpdxMojo.java
@@ -1,0 +1,61 @@
+package org.spdx.maven;
+
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+
+import org.spdx.core.InvalidSPDXAnalysisException;
+import org.spdx.maven.utils.AbstractDependencyBuilder;
+import org.spdx.maven.utils.AbstractDocumentBuilder;
+import org.spdx.maven.utils.LicenseMapperException;
+import org.spdx.maven.utils.SpdxV2DependencyBuilder;
+import org.spdx.maven.utils.SpdxV2DocumentBuilder;
+import org.spdx.maven.utils.SpdxV3DependencyBuilder;
+import org.spdx.maven.utils.SpdxV3DocumentBuilder;
+
+
+import java.util.List;
+import java.util.Arrays;
+
+@Mojo( name = "aggregateSPDX",
+        defaultPhase = LifecyclePhase.VERIFY,
+        requiresOnline = true,
+        threadSafe = true )
+public class AggregateSpdxMojo extends CreateSpdxMojo {
+
+    @Override
+    protected void buildSpdxDependencyInformation( AbstractDocumentBuilder builder, OutputFormat outputFormatEnum )
+            throws DependencyGraphBuilderException, LicenseMapperException, InvalidSPDXAnalysisException {
+        AbstractDependencyBuilder dependencyBuilder;
+        if ( builder instanceof SpdxV3DocumentBuilder)
+        {
+            dependencyBuilder = new SpdxV3DependencyBuilder( ( SpdxV3DocumentBuilder ) builder, createExternalRefs,
+                    generatePurls, useArtifactID, includeTransitiveDependencies );
+        }
+        else
+        {
+            dependencyBuilder = new SpdxV2DependencyBuilder( ( SpdxV2DocumentBuilder ) builder, createExternalRefs,
+                    generatePurls, useArtifactID, includeTransitiveDependencies );
+        }
+        if ( session != null )
+        {
+            List<MavenProject> projects = session.getAllProjects(); //includes the current project
+            if ( !projects.isEmpty() )
+            {
+                getLog().info( "List of projects that will be aggregated into one file: "
+                        + Arrays.toString( projects.toArray() ) );
+                for ( MavenProject project : projects )
+                {
+                    ProjectBuildingRequest request = new DefaultProjectBuildingRequest( session.getProjectBuildingRequest() );
+                    request.setProject( project );
+                    DependencyNode parentNode = dependencyGraphBuilder.buildDependencyGraph( request, null );
+                    dependencyBuilder.addMavenDependencies( mavenProjectBuilder, session, project, parentNode, builder.getProjectPackage() );
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/spdx/maven/CreateSpdxMojo.java
+++ b/src/main/java/org/spdx/maven/CreateSpdxMojo.java
@@ -117,13 +117,13 @@ public class CreateSpdxMojo extends AbstractMojo
     private MavenProjectHelper projectHelper;
 
     @Component
-    private ProjectBuilder mavenProjectBuilder;
+    protected ProjectBuilder mavenProjectBuilder;
 
     @Component
-    private MavenSession session;
+    protected MavenSession session;
 
     @Component(hint = "default")
-    private DependencyGraphBuilder dependencyGraphBuilder;
+    protected DependencyGraphBuilder dependencyGraphBuilder;
 
     // Parameters for the plugin
     /**
@@ -460,7 +460,7 @@ public class CreateSpdxMojo extends AbstractMojo
      * @since 0.6.3
      */
     @Parameter( defaultValue = "true" )
-    private boolean createExternalRefs;
+    protected boolean createExternalRefs;
 
     /**
      * If true, all transitive dependencies will be included in the SPDX document.  If false,
@@ -469,7 +469,7 @@ public class CreateSpdxMojo extends AbstractMojo
      * @since 0.6.3
      */
     @Parameter( defaultValue = "true" )
-    private boolean includeTransitiveDependencies;
+    protected boolean includeTransitiveDependencies;
 
      /**
       * Skip goal execution.
@@ -484,14 +484,14 @@ public class CreateSpdxMojo extends AbstractMojo
      * Otherwise, ${project.name} will be used
      */
     @Parameter( property = "spdx.useArtifactID" )
-    private boolean useArtifactID;
+    protected boolean useArtifactID;
 
     /**
      * If true, adds an external reference to every package with category "PACKAGE-MANAGER", type "purl"
      * and locator "pkg:maven/${project.groupId}/${project.artifactId}@${project.version}".
      */
     @Parameter( property = "spdx.generatePurls" )
-    private boolean generatePurls = true;
+    protected boolean generatePurls = true;
 
     public void execute() throws MojoExecutionException
     {
@@ -662,7 +662,7 @@ public class CreateSpdxMojo extends AbstractMojo
      * @throws LicenseMapperException on errors related to mapping Maven licenses to SPDX licenses
      * @throws InvalidSPDXAnalysisException on SPDX parsing errors
      */
-    private void buildSpdxDependencyInformation( AbstractDocumentBuilder builder, OutputFormat outputFormatEnum )
+    protected void buildSpdxDependencyInformation( AbstractDocumentBuilder builder, OutputFormat outputFormatEnum )
         throws LicenseMapperException, InvalidSPDXAnalysisException, DependencyGraphBuilderException
     {
         AbstractDependencyBuilder dependencyBuilder;


### PR DESCRIPTION
I made an aggregateSpdx maven goal that will add the dependencies of modules into the top-level spdx file. It extends the createSpdx goal but overrides the buildSpdxDependencyInformation to add the modules' dependencies. To implement this function without duplicating dependencies in the spdx file, I had to add logic to the AbstractDependencyBuilder class. 

Why we should implement this: The createSpdx goal doesn't add dependencies of modules into the parent's spdx.json file; instead, it triggers the spdx-maven-plugin to run for the children if the plugin is present in the modules' poms. While this is a nice feature, it would be nice to consolidate everything into one file.

To hero:

1. Check out the aggregateSpdx branch
2. Navigate to the project's pom.xml and run `mvn clean install`
3. A new test will run on the simple-aggregate-it project. This project has the "advanced" project listed as a module. Make sure that the test runs without errors. 
4. Navigate to target/it/simple-aggregate-it and examine the build.log file. It should provide a list of projects that will be aggregated (ctrl + f "List of projects that will be aggregated into one file:"
5. There should be one duplicated dependency (junit:junit:4.3.12). This is just there to express that it caught the same dependency listed in the parent and in the "advanced" project
6. Now, go to target/it/simple-aggregate-it/target/site and open the spdx file. Ensure that the dependencies from both the parent pom and the "advanced" pom are present