### PR TITLE
allow to exclude source code files from the license scan

### DIFF
--- a/src/main/java/org/spdx/maven/CreateSpdxMojo.java
+++ b/src/main/java/org/spdx/maven/CreateSpdxMojo.java
@@ -483,6 +483,16 @@ public class CreateSpdxMojo extends AbstractMojo
     private String outputFormat;
 
     /**
+     * Type of the SPDX file.  One of:
+     * - consolidated - include source code files to the license scan
+     * - build - exclude source code files from the license scan
+     *
+     * @since 1.0.0
+     */
+    @Parameter( defaultValue = "consolidated" )
+    private String sbomType;
+
+    /**
      * If true, external document references will be created for any dependencies which
      * contain SPDX documents.  If false, the dependent package information will be copied
      * from the SPDX document into the generated SPDX document.
@@ -611,8 +621,9 @@ public class CreateSpdxMojo extends AbstractMojo
             logFileSpecificInfo( pathSpecificInformation );
         }
 
-        builder.collectSpdxFileInformation( sources, mavenProject.getBasedir().getAbsolutePath(), defaultFileInformation, pathSpecificInformation, getChecksumAlgorithms() );
-
+        builder.collectSpdxFileInformation( sources, mavenProject.getBasedir().getAbsolutePath(), defaultFileInformation, 
+                pathSpecificInformation, getChecksumAlgorithms(), !"build".equals(sbomType) );
+    
         // add dependencies information
         try
         {

--- a/src/main/java/org/spdx/maven/utils/AbstractDocumentBuilder.java
+++ b/src/main/java/org/spdx/maven/utils/AbstractDocumentBuilder.java
@@ -102,14 +102,17 @@ public abstract class AbstractDocumentBuilder
      * @param sources                     Source directories to be included in the document
      * @param baseDir                     project base directory used to construct the relative paths for the SPDX
      *                                    files
+     * @param defaultFileInformation      Information on default SPDX field data for the files
      * @param pathSpecificInformation     Map of path to file information used to override the default file information
      * @param checksumAlgorithms          algorithms to use to generate checksums
+     * @param attachFiles                 attach scanned files to the output SPDX document (V2 only)
      * @throws SpdxBuilderException       on errors collecting files
      */
     public abstract void collectSpdxFileInformation( List<FileSet> sources, String baseDir,
                                                         SpdxDefaultFileInformation defaultFileInformation,
                                                         HashMap<String, SpdxDefaultFileInformation> pathSpecificInformation,
-                                                        Set<String> checksumAlgorithms ) throws SpdxBuilderException;
+                                                        Set<String> checksumAlgorithms,
+                                                        boolean attachFiles ) throws SpdxBuilderException;
 
     /**
      * Saves the SPDX document to the file

--- a/src/main/java/org/spdx/maven/utils/SpdxV2FileCollector.java
+++ b/src/main/java/org/spdx/maven/utils/SpdxV2FileCollector.java
@@ -80,6 +80,7 @@ public class SpdxV2FileCollector extends AbstractFileCollector
      * @param relationshipType        Type of relationship to the project package
      * @param projectPackage          Package to which the files belong
      * @param spdxDoc                 SPDX document which contains the extracted license infos that may be needed for license parsing
+     * @param algorithms              algorithms to use to generate checksums
      *
      * @throws SpdxCollectionException on incompatible types in an SPDX collection
      */

--- a/src/main/java/org/spdx/maven/utils/SpdxV3DocumentBuilder.java
+++ b/src/main/java/org/spdx/maven/utils/SpdxV3DocumentBuilder.java
@@ -486,7 +486,8 @@ public class SpdxV3DocumentBuilder
     public void collectSpdxFileInformation( List<FileSet> sources, String baseDir,
                                             SpdxDefaultFileInformation defaultFileInformation,
                                             HashMap<String, SpdxDefaultFileInformation> pathSpecificInformation,
-                                            Set<String> checksumAlgorithms ) throws SpdxBuilderException
+                                            Set<String> checksumAlgorithms,
+                                            boolean attachFiles) throws SpdxBuilderException
     {
         SpdxV3FileCollector fileCollector = new SpdxV3FileCollector( customIdToUri );
         try

--- a/src/main/java/org/spdx/maven/utils/SpdxV3FileCollector.java
+++ b/src/main/java/org/spdx/maven/utils/SpdxV3FileCollector.java
@@ -113,6 +113,7 @@ public class SpdxV3FileCollector extends AbstractFileCollector
      * @param relationshipType        Type of relationship to the project package
      * @param projectPackage          Package to which the files belong
      * @param spdxDoc                 SPDX document which contains the extracted license infos that may be needed for license parsing
+     * @param algorithms              algorithms to use to generate checksums
      *
      * @throws SpdxCollectionException on incompatible types in an SPDX collection
      */

--- a/src/test/java/org/spdx/maven/utils/TestSpdxV2FileCollector.java
+++ b/src/test/java/org/spdx/maven/utils/TestSpdxV2FileCollector.java
@@ -624,9 +624,6 @@ public class TestSpdxV2FileCollector
     @Test
     public void testGenerateChecksums() throws SpdxCollectionException, InvalidSPDXAnalysisException
     {
-        SpdxV2FileCollector collector = new SpdxV2FileCollector();
-        collector.collectFiles( this.fileSets, this.directory.getAbsolutePath(), this.defaultFileInformation,
-                new HashMap<>(), spdxPackage, RelationshipType.GENERATES, spdxDoc, sha1Algorithm );
         File spdxFile = new File( filePaths[0] );
 
         Set<String> checksumAlgorithmSet = new HashSet<>();

--- a/src/test/java/org/spdx/maven/utils/TestSpdxV3FileCollector.java
+++ b/src/test/java/org/spdx/maven/utils/TestSpdxV3FileCollector.java
@@ -625,9 +625,6 @@ public class TestSpdxV3FileCollector
     @Test
     public void testGenerateChecksums() throws SpdxCollectionException, InvalidSPDXAnalysisException
     {
-        SpdxV3FileCollector collector = new SpdxV3FileCollector( customIdMap );
-        collector.collectFiles( this.fileSets, this.directory.getAbsolutePath(), this.defaultFileInformation,
-                new HashMap<>(), spdxPackage, RelationshipType.GENERATES, spdxDoc, sha1Algorithm );
         File spdxFile = new File( filePaths[0] );
 
         Set<String> checksumAlgorithmSet = new HashSet<>();


### PR DESCRIPTION
This PR will add the following `sbomType` modes `build` and `consolidated` mentioned in #131
I am not sure anyone will need the `source` mode, so i have skipped this for now.