### PR TITLE
Ensure a unmappable maven license will result in NOASSERTION

### DIFF
--- a/src/main/java/org/spdx/maven/utils/MavenToSpdxLicenseMapper.java
+++ b/src/main/java/org/spdx/maven/utils/MavenToSpdxLicenseMapper.java
@@ -211,7 +211,7 @@ public class MavenToSpdxLicenseMapper
      * returned.  if a single license is supplied, and a URL can be found matching a listed license, the listed license
      * is returned.  if a single license is supplied, and a URL can not be found matching a listed license,
      * SpdxNoAssertion is returned.  If multiple licenses are supplied, a conjunctive license is returned containing all
-     * mapped SPDX licenses.
+     * mapped SPDX licenses or a single SpdxNoAssertionLicense if any of the multiple licenses can not be resolved.
      *
      * @param licenseList list of licenses
      * @param spdxDoc     SPDX document which will hold the licenses
@@ -231,6 +231,8 @@ public class MavenToSpdxLicenseMapper
             if ( listedLicense != null )
             {
                 spdxLicenses.add( listedLicense );
+            } else {
+                return new SpdxNoAssertionLicense();
             }
         }
         if (spdxLicenses.isEmpty())
@@ -277,7 +279,7 @@ public class MavenToSpdxLicenseMapper
      * returned.  if a single license is supplied, and a URL can be found matching a listed license, the listed license
      * is returned.  if a single license is supplied, and a URL can not be found matching a listed license,
      * SpdxNoAssertion is returned.  If multiple licenses are supplied, a conjunctive license is returned containing all
-     * mapped SPDX licenses.
+     * mapped SPDX licenses or a single NoAssertionLicense if any of the multiple licenses can not be resolved.
      *
      * @param licenseList list of Maven licenses
      * @param spdxDoc     SPDX document which will hold the licenses
@@ -298,6 +300,8 @@ public class MavenToSpdxLicenseMapper
             if ( listedLicense != null )
             {
                 spdxLicenses.add( listedLicense );
+            } else {
+                return new NoAssertionLicense();
             }
         }
         if (spdxLicenses.isEmpty())

--- a/src/test/java/org/spdx/maven/utils/TestMavenToSpdxLicenseMapper.java
+++ b/src/test/java/org/spdx/maven/utils/TestMavenToSpdxLicenseMapper.java
@@ -19,6 +19,7 @@ import org.spdx.library.LicenseInfoFactory;
 import org.spdx.library.ModelCopyManager;
 import org.spdx.library.SpdxModelFactory;
 import org.spdx.library.model.v2.SpdxDocument;
+import org.spdx.library.model.v2.SpdxNoAssertion;
 import org.spdx.library.model.v3_0_1.core.Element;
 import org.spdx.storage.simple.InMemSpdxStore;
 
@@ -168,7 +169,7 @@ public class TestMavenToSpdxLicenseMapper
         licenseList.add( licenseM );
         org.spdx.library.model.v2.license.AnyLicenseInfo result = MavenToSpdxLicenseMapper.getInstance().mavenLicenseListToSpdxV2License(
                 licenseList, spdxDoc );
-        org.spdx.library.model.v2.license.AnyLicenseInfo expected = LicenseInfoFactory.parseSPDXLicenseStringCompatV2( APACHE_SPDX_ID + " AND " + MIT_SPDX_ID );
+        org.spdx.library.model.v2.license.AnyLicenseInfo expected = LicenseInfoFactory.parseSPDXLicenseStringCompatV2(APACHE_SPDX_ID + " AND " + MIT_SPDX_ID );
         assertEquals( expected, result );
     }
     
@@ -200,7 +201,7 @@ public class TestMavenToSpdxLicenseMapper
         licenseList.add( licenseM );
         org.spdx.library.model.v2.license.AnyLicenseInfo result = MavenToSpdxLicenseMapper.getInstance().mavenLicenseListToSpdxV2License(
                 licenseList, spdxDoc );
-        org.spdx.library.model.v2.license.AnyLicenseInfo expected = LicenseInfoFactory.parseSPDXLicenseStringCompatV2( APACHE_SPDX_ID );
+        org.spdx.library.model.v2.license.AnyLicenseInfo expected = LicenseInfoFactory.parseSPDXLicenseStringCompatV2( "NOASSERTION" );
         assertEquals( expected, result );
     }
     
@@ -216,7 +217,7 @@ public class TestMavenToSpdxLicenseMapper
         licenseList.add( licenseM );
         org.spdx.library.model.v3_0_1.simplelicensing.AnyLicenseInfo result = MavenToSpdxLicenseMapper.getInstance().mavenLicenseListToSpdxV3License(
                 licenseList, spdxV3Doc );
-        org.spdx.library.model.v3_0_1.simplelicensing.AnyLicenseInfo expected = LicenseInfoFactory.parseSPDXLicenseString( APACHE_SPDX_ID );
+        org.spdx.library.model.v3_0_1.simplelicensing.AnyLicenseInfo expected = LicenseInfoFactory.parseSPDXLicenseString( "NOASSERTION" );
         assertEquals( expected, result );
     }
 }


### PR DESCRIPTION
This is the PR related to #187, with a slightly different solution.
The `Apache-2.0 AND NOASSERTION` is not parsable and perhaps a invalid expression.
So this PR will ensure `NOASSERTION` is returned from parsing.