### PR TITLE
Ensure no file relations are added for sbomType 'build'

### DIFF
--- a/src/main/java/org/spdx/maven/CreateSpdxMojo.java
+++ b/src/main/java/org/spdx/maven/CreateSpdxMojo.java
@@ -621,9 +621,12 @@ public class CreateSpdxMojo extends AbstractMojo
             logFileSpecificInfo( pathSpecificInformation );
         }
 
-        builder.collectSpdxFileInformation( sources, mavenProject.getBasedir().getAbsolutePath(), defaultFileInformation, 
-                pathSpecificInformation, getChecksumAlgorithms(), !"build".equals(sbomType) );
-    
+        if ( !"build".equals(sbomType) )
+        {
+            builder.collectSpdxFileInformation( sources, mavenProject.getBasedir().getAbsolutePath(), defaultFileInformation, 
+                    pathSpecificInformation, getChecksumAlgorithms() );
+        }
+
         // add dependencies information
         try
         {

--- a/src/main/java/org/spdx/maven/utils/AbstractDocumentBuilder.java
+++ b/src/main/java/org/spdx/maven/utils/AbstractDocumentBuilder.java
@@ -105,14 +105,12 @@ public abstract class AbstractDocumentBuilder
      * @param defaultFileInformation      Information on default SPDX field data for the files
      * @param pathSpecificInformation     Map of path to file information used to override the default file information
      * @param checksumAlgorithms          algorithms to use to generate checksums
-     * @param attachFiles                 attach scanned files to the output SPDX document (V2 only)
      * @throws SpdxBuilderException       on errors collecting files
      */
     public abstract void collectSpdxFileInformation( List<FileSet> sources, String baseDir,
                                                         SpdxDefaultFileInformation defaultFileInformation,
                                                         HashMap<String, SpdxDefaultFileInformation> pathSpecificInformation,
-                                                        Set<String> checksumAlgorithms,
-                                                        boolean attachFiles ) throws SpdxBuilderException;
+                                                        Set<String> checksumAlgorithms ) throws SpdxBuilderException;
 
     /**
      * Saves the SPDX document to the file

--- a/src/main/java/org/spdx/maven/utils/SpdxV2DocumentBuilder.java
+++ b/src/main/java/org/spdx/maven/utils/SpdxV2DocumentBuilder.java
@@ -367,39 +367,33 @@ public class SpdxV2DocumentBuilder
     public void collectSpdxFileInformation( List<FileSet> sources, String baseDir,
                                             SpdxDefaultFileInformation defaultFileInformation,
                                             HashMap<String, SpdxDefaultFileInformation> pathSpecificInformation,
-                                            Set<String> checksumAlgorithms, boolean attachFiles ) throws SpdxBuilderException
+                                            Set<String> checksumAlgorithms ) throws SpdxBuilderException
     {
         SpdxV2FileCollector fileCollector = new SpdxV2FileCollector();
         try
         {
             fileCollector.collectFiles( sources, baseDir, defaultFileInformation,
                     pathSpecificInformation, projectPackage, RelationshipType.GENERATES, spdxDoc, checksumAlgorithms );
-            if ( attachFiles )
-            {
-                projectPackage.getFiles().addAll( fileCollector.getFiles() );
-            }
+            projectPackage.getFiles().addAll( fileCollector.getFiles() );
             projectPackage.getLicenseInfoFromFiles().addAll( fileCollector.getLicenseInfoFromFiles() );
         }
         catch ( SpdxCollectionException|InvalidSPDXAnalysisException e )
         {
             throw new SpdxBuilderException( "Error collecting SPDX file information", e );
         }
-        if ( attachFiles )
+        try
         {
-            try
-            {
-                String spdxFileName = spdxFile.getPath().replace( "\\", "/" );
-                projectPackage.setPackageVerificationCode( fileCollector.getVerificationCode( spdxFileName, spdxDoc ) );
-                projectPackage.setFilesAnalyzed( true );
-            }
-            catch ( NoSuchAlgorithmException e )
-            {
-                throw new SpdxBuilderException( "Unable to calculate verification code", e );
-            }
-            catch ( InvalidSPDXAnalysisException e )
-            {
-                throw new SpdxBuilderException( "Unable to update verification code", e );
-            }
+            String spdxFileName = spdxFile.getPath().replace( "\\", "/" );
+            projectPackage.setPackageVerificationCode( fileCollector.getVerificationCode( spdxFileName, spdxDoc ) );
+            projectPackage.setFilesAnalyzed( true );
+        }
+        catch ( NoSuchAlgorithmException e )
+        {
+            throw new SpdxBuilderException( "Unable to calculate verification code", e );
+        }
+        catch ( InvalidSPDXAnalysisException e )
+        {
+            throw new SpdxBuilderException( "Unable to update verification code", e );
         }
     }
 

--- a/src/main/java/org/spdx/maven/utils/SpdxV3DocumentBuilder.java
+++ b/src/main/java/org/spdx/maven/utils/SpdxV3DocumentBuilder.java
@@ -486,8 +486,7 @@ public class SpdxV3DocumentBuilder
     public void collectSpdxFileInformation( List<FileSet> sources, String baseDir,
                                             SpdxDefaultFileInformation defaultFileInformation,
                                             HashMap<String, SpdxDefaultFileInformation> pathSpecificInformation,
-                                            Set<String> checksumAlgorithms,
-                                            boolean attachFiles) throws SpdxBuilderException
+                                            Set<String> checksumAlgorithms) throws SpdxBuilderException
     {
         SpdxV3FileCollector fileCollector = new SpdxV3FileCollector( customIdToUri );
         try


### PR DESCRIPTION
It looks like `fileCollector.collectFiles` does add relations while collecting files, so it is best to skip this for sbomType 'build'.