### PR TITLE
Fix Markdown warnings in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,18 @@
 Contributing
 ============
+
 Thank you for your interest in `spdx-maven-plugin`. The project is open-source software, and bug reports, suggestions, and most especially patches are welcome.
 
 Issues
 ------
+
 `spdx-maven-plugin` has a [project page on GitHub](https://github.com/spdx/spdx-maven-plugin) where you can [create an issue](https://github.com/spdx/spdx-maven-plugin/issues/new/choose) to report a bug, make a suggestion, or propose a substantial change or improvement that you might like to make. You may also wish to contact the SPDX working group technical team through its mailing list, [spdx-tech@lists.spdx.org](mailto:spdx-tech@lists.spdx.org).
 
 If you would like to work on a fix for any issue, please assign the issue to yourself prior to creating a Pull Request.
 
 Pull Requests
 -------
+
 The source code for `spdx-maven-plugin` is hosted on [github.com/spdx/spdx-maven-plugin](https://github.com/spdx/spdx-maven-plugin). Please review [open pull requests](https://github.com/spdx/spdx-maven-plugin/pulls) and [active branches](https://github.com/spdx/spdx-maven-plugin/branches) before committing time to a substantial revision. Work along similar lines may already be in progress.
 
 To submit a pull request via GitHub, fork the repository, create a topic branch from `master` for your work, and send a pull request when ready. If you prefer to send a patch or grant access to pull from your own Git repository, please contact the project's contributors by e-mail.
@@ -20,8 +23,10 @@ Once implemented, submit a pull request with `spec/X.X` branch as the parent bra
 
 Licensing
 ---------
+
 However you choose to contribute, please sign-off in each of your commits that you license your contributions under the terms of [the Developer Certificate of Origin](https://developercertificate.org/). Git has utilities for signing off on commits: `git commit -s` signs a current commit, and `git rebase --signoff <revision-range>` retroactively signs a range of past commits.
 
 Coding Style
 ------------
+
 This project follows the [Maven Code Style](https://maven.apache.org/developers/conventions/code.html).

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
-SPDX Maven Plugin is a plugin to Maven which produces [Software Package Data Exchange (SPDX)](https://spdx.dev/) documents for artifacts described in the POM file.
+# SPDX Maven Plugin
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.spdx/spdx-maven-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.spdx/spdx-maven-plugin)
 
-# Goal Overview
+SPDX Maven Plugin is a plugin to Maven which produces [Software Package Data Exchange (SPDX)](https://spdx.dev/) documents for artifacts described in the [Maven POM file](https://maven.apache.org/pom.html).
+
+## Goal Overview
 
 `spdx:createSPDX` creates an SPDX document for artifacts defined in the POM file. It will replace any existing SPDX documents.
 
-# Code quality badges
+## Code quality badges
 
-|   [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=spdx-maven-plugin&metric=bugs)](https://sonarcloud.io/dashboard?id=spdx-maven-plugin)    | [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-maven-plugin&metric=security_rating)](https://sonarcloud.io/dashboard?id=spdx-maven-plugin) | [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-maven-plugin&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=spdx-maven-plugin) | [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=spdx-maven-plugin&metric=sqale_index)](https://sonarcloud.io/dashboard?id=spdx-maven-plugin) |
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=spdx-maven-plugin&metric=bugs)](https://sonarcloud.io/dashboard?id=spdx-maven-plugin)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-maven-plugin&metric=security_rating)](https://sonarcloud.io/dashboard?id=spdx-maven-plugin)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=spdx-maven-plugin&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=spdx-maven-plugin)
+[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=spdx-maven-plugin&metric=sqale_index)](https://sonarcloud.io/dashboard?id=spdx-maven-plugin)
 
-# Usage
+## Usage
 
 In the build plugins section, add the plugin with `createSPDX` goal:
 
@@ -19,7 +24,7 @@ In the build plugins section, add the plugin with `createSPDX` goal:
         <groupId>org.spdx</groupId>
         <artifactId>spdx-maven-plugin</artifactId>
         <!-- please check for updates on https://search.maven.org/search?q=a:spdx-maven-plugin -->
-        <version>0.6.5</version>
+        <version>0.7.4</version>
         <executions>
             <execution>
                 <id>build-spdx</id>
@@ -39,7 +44,7 @@ In the build plugins section, add the plugin with `createSPDX` goal:
 
 Then invoke with `mvn spdx:createSPDX` and your SPDX file will be generated in `./target/site/{groupId}_{artifactId}-{version}.spdx`.
 
-# Additional Configuration
+## Additional Configuration
 
 See [`createSPDX` goal documentation](http://spdx.github.io/spdx-maven-plugin/createSPDX-mojo.html) for complete details.
 
@@ -61,11 +66,14 @@ SPDX standard licenses ID's should be used.  If no SPDX standard license
 is available, a `nonStandardLicense` must be declared as a parameter including
 a unique license ID and the verbatim license text.
 
-# Example
+## Example
+
 See the file [`src/it/advanced/pom.xml`](src/it/advanced/pom.xml) for an example project using the spdx-maven-plugin.
 
-# Contributing
+## Contributing
+
 See the [CONTRIBUTING.MD](CONTRIBUTING.md) documentation.
 
-# License
+## License
+
 This project is licensed under the Apache 2.0 License


### PR DESCRIPTION
- Add title (fix Markdownlint MD041)
- Make the rest of headings H2 (fix MD025)
- Add blanklines around headings (fix MD022)
- Update plugin version example
- Add newline character at the end of line at the end of file