### PR TITLE
Update SPDX libraries version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,13 +41,6 @@
     <tag>master</tag>
   </scm>
 
-  <repositories>
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-    </repository>
-  </repositories>
-
   <distributionManagement>
     <repository>
       <id>ossrh</id>
@@ -105,17 +98,22 @@
     <dependency>
       <groupId>org.spdx</groupId>
       <artifactId>java-spdx-library</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.spdx</groupId>
       <artifactId>spdx-rdf-store</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.spdx</groupId>
       <artifactId>spdx-jackson-store</artifactId>
-      <version>2.0.0-RC2</version>
+      <version>2.0.0</version>
+    </dependency>
+    <dependency>
+    	<groupId>org.spdx</groupId>
+    	<artifactId>spdx-v3jsonld-store</artifactId>
+    	<version>1.0.0</version>
     </dependency>
 
     <dependency>
@@ -153,11 +151,6 @@
       <artifactId>aether-transport-http</artifactId>
       <version>1.1.0</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-    	<groupId>org.spdx</groupId>
-    	<artifactId>spdx-v3jsonld-store</artifactId>
-    	<version>1.0.0-RC3</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,9 +111,9 @@
       <version>2.0.0</version>
     </dependency>
     <dependency>
-    	<groupId>org.spdx</groupId>
-    	<artifactId>spdx-v3jsonld-store</artifactId>
-    	<version>1.0.0</version>
+      <groupId>org.spdx</groupId>
+      <artifactId>spdx-v3jsonld-store</artifactId>
+      <version>1.0.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
- java-spdx-library to 2.0.0
- spdx-rdf-store to 2.0.0
- spdx-jackson-store to 2.0.0
- spdx-v3jsonld-store to 1.0.0
- Remove jitpack.io from repositories