### PR TITLE
Update dependencies to latest patch version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-dependency-tree</artifactId>
-      <version>3.1.0</version>
+      <version>3.1.1</version>
     </dependency>
 
     <dependency>
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -276,7 +276,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.4.3</version>
+        <version>3.4.5</version>
         <reportSets>
           <reportSet>
             <reports>
@@ -334,7 +334,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-invoker-plugin</artifactId>
-            <version>3.6.0</version>
+            <version>3.6.1</version>
             <configuration>
               <debug>false</debug>
               <streamLogsOnFailures>true</streamLogsOnFailures>

--- a/src/it/advanced-v3/pom.xml
+++ b/src/it/advanced-v3/pom.xml
@@ -50,20 +50,20 @@
         <!-- Force the dependency version greater or equal to 0.11.0 for Jena - resolves vulnerability -->
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.14.0</version>
+            <version>0.14.2</version>
             <type>pom</type>
         </dependency>
         <dependency>
         <!-- Force the dependency version to 2.12.7.1 for Jena - resolves vulnerability -->
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.7.1</version>
+            <version>2.12.7.2</version>
         </dependency>
         <dependency>
         <!-- Force the dependency version to 1.26.0 for Jena - resolves vulnerability -->
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.26.0</version>
+            <version>1.26.2</version>
         </dependency>
         <dependency>
            <groupId>org.apache.jena</groupId>
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>4.1.1</version>
+            <version>4.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
@@ -115,12 +115,12 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.15.3</version>
+            <version>1.15.4</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
+            <version>32.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.github.spullara.mustache.java</groupId>
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
+            <version>2.17.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/src/it/advanced/pom.xml
+++ b/src/it/advanced/pom.xml
@@ -50,20 +50,20 @@
         <!-- Force the dependency version greater or equal to 0.11.0 for Jena - resolves vulnerability -->
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.14.0</version>
+            <version>0.14.2</version>
             <type>pom</type>
         </dependency>
         <dependency>
         <!-- Force the dependency version to 2.12.7.1 for Jena - resolves vulnerability -->
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.7.1</version>
+            <version>2.12.7.2</version>
         </dependency>
         <dependency>
         <!-- Force the dependency version to 1.26.0 for Jena - resolves vulnerability -->
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.26.0</version>
+            <version>1.26.2</version>
         </dependency>
         <dependency>
            <groupId>org.apache.jena</groupId>
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <version>4.1.1</version>
+            <version>4.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.poi</groupId>
@@ -115,12 +115,12 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.15.3</version>
+            <version>1.15.4</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>32.0.0-jre</version>
+            <version>32.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.github.spullara.mustache.java</groupId>
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
+            <version>2.17.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/src/it/simple-bundle-it/pom.xml
+++ b/src/it/simple-bundle-it/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
-      <version>1.1.10.5</version>
+      <version>1.1.10.7</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Update dependencies to latest patch version.

mvn test passed with these projects:
- pom.xml (at root)
- src/it/advanced/pom.xml
- src/it/advanced-v3/pom.xml

Requires #196, particularly the upgrade of spdx-v3jsonld-store to 1.0.0.
