### PR TITLE
Use getLicenseComment() instead of getLicensComment()

### DIFF
--- a/src/main/java/org/spdx/maven/SnippetInfo.java
+++ b/src/main/java/org/spdx/maven/SnippetInfo.java
@@ -100,6 +100,11 @@ public class SnippetInfo
         return this.copyrightText;
     }
 
+    /**
+     * @deprecated Use {@link #getLicenseComment()} instead.
+     * @return the licenseComment
+     */
+    @Deprecated
     public String getLicensComment()
     {
         return this.licenseComment;

--- a/src/main/java/org/spdx/maven/utils/SpdxV2DependencyBuilder.java
+++ b/src/main/java/org/spdx/maven/utils/SpdxV2DependencyBuilder.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -57,7 +56,6 @@ import org.spdx.maven.LicenseOverwrite;
 import org.spdx.maven.OutputFormat;
 import org.spdx.spdxRdfStore.RdfStore;
 import org.spdx.storage.ISerializableModelStore;
-import org.spdx.storage.IModelStore.IdType;
 import org.spdx.storage.simple.InMemSpdxStore;
 
 /**

--- a/src/main/java/org/spdx/maven/utils/SpdxV2FileCollector.java
+++ b/src/main/java/org/spdx/maven/utils/SpdxV2FileCollector.java
@@ -38,7 +38,6 @@ import org.spdx.library.model.v2.license.AnyLicenseInfo;
 import org.spdx.library.model.v2.license.InvalidLicenseStringException;
 import org.spdx.maven.Checksum;
 import org.spdx.maven.SnippetInfo;
-import org.spdx.storage.IModelStore.IdType;
 
 import javax.annotation.Nullable;
 
@@ -251,7 +250,7 @@ public class SpdxV2FileCollector extends AbstractFileCollector
                                                         snippet.getCopyrightText(), spdxFile, 
                                                         snippet.getByteRangeStart(), snippet.getByteRangeEnd() )
                         .setComment( snippet.getComment() )
-                        .setLicenseComments( snippet.getLicensComment() )
+                        .setLicenseComments( snippet.getLicenseComment() )
                         .setLineRange( snippet.getLineRangeStart(), snippet.getLineRangeEnd() )
                         .build();
     }

--- a/src/main/java/org/spdx/maven/utils/SpdxV3FileCollector.java
+++ b/src/main/java/org/spdx/maven/utils/SpdxV3FileCollector.java
@@ -279,7 +279,7 @@ public class SpdxV3FileCollector extends AbstractFileCollector
         {
             comment = "";
         }
-        String licenseComment = snippet.getLicensComment();
+        String licenseComment = snippet.getLicenseComment();
         if ( Objects.nonNull( licenseComment ) && !licenseComment.isBlank() )
         {
             comment = comment + "; License: " + licenseComment;


### PR DESCRIPTION
- Use getLicenseComment() instead of getLicensComment()
- Deprecate getLicensComment()