### PR TITLE
Update spdx-jackson-store to version 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>org.spdx</groupId>
       <artifactId>spdx-jackson-store</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.spdx</groupId>


### PR DESCRIPTION
Fixes an issue with reproducible builds by sorting document property arrays.

Fixes #177