### PR TITLE
Update jackson store library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>org.spdx</groupId>
       <artifactId>spdx-jackson-store</artifactId>
-      <version>2.0.1</version>
+      <version>2.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.spdx</groupId>


### PR DESCRIPTION
Fixes #203 - fixes sort inconsistency in the SPDX JSON output

Note: the CI will likely fail until the new release works its way through maven central