### PR TITLE
Add support for Maven 4

### DIFF
--- a/src/main/java/org/spdx/maven/CreateSpdxMojo.java
+++ b/src/main/java/org/spdx/maven/CreateSpdxMojo.java
@@ -120,7 +120,7 @@ public class CreateSpdxMojo extends AbstractMojo
         SpdxModelFactory.init();
     }
 
-    @Component
+    @Parameter( defaultValue = "${project}", readonly = true )
     private MavenProject mavenProject;
 
     @Component
@@ -129,7 +129,7 @@ public class CreateSpdxMojo extends AbstractMojo
     @Component
     protected ProjectBuilder mavenProjectBuilder;
 
-    @Component
+    @Parameter( defaultValue = "${session}", readonly = true )
     protected MavenSession session;
 
     @Component(hint = "default")

--- a/src/main/java/org/spdx/maven/utils/AbstractFileCollector.java
+++ b/src/main/java/org/spdx/maven/utils/AbstractFileCollector.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
@@ -233,6 +234,15 @@ public abstract class AbstractFileCollector
         }
 
         return checksums;
+    }
+
+    /**
+     * @param file file which is the target for the path string
+     * @param baseDir base directory of the SPDX archive or project containing the file
+     * @return a file path for the file relative to the baseDir
+     */
+    protected static String toRelativeFilePath( File file, String baseDir ) {
+        return Path.of( baseDir ).relativize( file.toPath() ).toString().replace( '\\', '/' );
     }
 
 }

--- a/src/main/java/org/spdx/maven/utils/SpdxV2FileCollector.java
+++ b/src/main/java/org/spdx/maven/utils/SpdxV2FileCollector.java
@@ -97,23 +97,15 @@ public class SpdxV2FileCollector extends AbstractFileCollector
             {
                 String filePath = fileSet.getDirectory() + File.separator + includedFile;
                 File file = new File( filePath );
-                String relativeFilePath = file.getAbsolutePath().substring( baseDir.length() + 1 ).replace( '\\', '/' );
+                String relativeFilePath = toRelativeFilePath( file, baseDir );
                 SpdxDefaultFileInformation fileInfo = findDefaultFileInformation( relativeFilePath,
                         pathSpecificInformation );
                 if ( fileInfo == null )
                 {
                     fileInfo = defaultFileInformation;
                 }
-
-                String outputFileName;
-                if ( fileSet.getOutputDirectory() != null )
-                {
-                    outputFileName = fileSet.getOutputDirectory() + File.separator + includedFile;
-                }
-                else
-                {
-                    outputFileName = file.getAbsolutePath().substring( baseDir.length() + 1 );
-                }
+                String outputFileName = Objects.nonNull( fileSet.getOutputDirectory() ) ?
+                        fileSet.getOutputDirectory() + File.separator + includedFile : relativeFilePath;
                 collectFile( file, outputFileName, fileInfo, relationshipType, projectPackage, spdxDoc, algorithms );
             }
         }

--- a/src/main/java/org/spdx/maven/utils/SpdxV3FileCollector.java
+++ b/src/main/java/org/spdx/maven/utils/SpdxV3FileCollector.java
@@ -130,23 +130,15 @@ public class SpdxV3FileCollector extends AbstractFileCollector
             {
                 String filePath = fileSet.getDirectory() + File.separator + includedFile;
                 File file = new File( filePath );
-                String relativeFilePath = file.getAbsolutePath().substring( baseDir.length() + 1 ).replace( '\\', '/' );
+                String relativeFilePath = toRelativeFilePath( file, baseDir );
                 SpdxDefaultFileInformation fileInfo = findDefaultFileInformation( relativeFilePath,
                         pathSpecificInformation );
                 if ( fileInfo == null )
                 {
                     fileInfo = defaultFileInformation;
                 }
-
-                String outputFileName;
-                if ( fileSet.getOutputDirectory() != null )
-                {
-                    outputFileName = fileSet.getOutputDirectory() + File.separator + includedFile;
-                }
-                else
-                {
-                    outputFileName = file.getAbsolutePath().substring( baseDir.length() + 1 );
-                }
+                String outputFileName = Objects.nonNull( fileSet.getOutputDirectory() ) ?
+                        fileSet.getOutputDirectory() + File.separator + includedFile : relativeFilePath;
                 collectFile( file, outputFileName, fileInfo, relationshipType, projectPackage, spdxDoc, algorithms );
             }
         }

--- a/src/test/java/org/spdx/maven/utils/TestSpdxV2FileCollector.java
+++ b/src/test/java/org/spdx/maven/utils/TestSpdxV2FileCollector.java
@@ -674,9 +674,5 @@ public class TestSpdxV2FileCollector
         result = AbstractFileCollector.toRelativeFilePath( new File( "/ghi/file.java" ),
                 "/abc/def" );
         assertEquals( "../../ghi/file.java", result );
-        // test DOS filenames
-        result = AbstractFileCollector.toRelativeFilePath( new File( "c:\\abc\\def\\ghi\\file.java" ),
-                "c:\\abc\\def" );
-        assertEquals( "ghi/file.java", result );
     }
 }

--- a/src/test/java/org/spdx/maven/utils/TestSpdxV2FileCollector.java
+++ b/src/test/java/org/spdx/maven/utils/TestSpdxV2FileCollector.java
@@ -658,4 +658,25 @@ public class TestSpdxV2FileCollector
             }
         }
     }
+
+    @Test
+    public void testToRelativeFilePath()
+    {
+        // test simple case
+        String result = AbstractFileCollector.toRelativeFilePath( new File( "/abc/def/ghi/file.java" ),
+                "/abc/def" );
+        assertEquals( "ghi/file.java", result );
+        // test level up
+        result = AbstractFileCollector.toRelativeFilePath( new File( "/abc/file.java" ),
+                "/abc/def" );
+        assertEquals( "../file.java", result );
+        // test not relative
+        result = AbstractFileCollector.toRelativeFilePath( new File( "/ghi/file.java" ),
+                "/abc/def" );
+        assertEquals( "../../ghi/file.java", result );
+        // test DOS filenames
+        result = AbstractFileCollector.toRelativeFilePath( new File( "c:\\abc\\def\\ghi\\file.java" ),
+                "c:\\abc\\def" );
+        assertEquals( "ghi/file.java", result );
+    }
 }

--- a/src/test/java/org/spdx/maven/utils/TestSpdxV2LicenseManager.java
+++ b/src/test/java/org/spdx/maven/utils/TestSpdxV2LicenseManager.java
@@ -51,6 +51,7 @@ public class TestSpdxV2LicenseManager
     private static final String TEST_SPDX_DOCUMENT_URL = "http://www.spdx.org/documents/test";
     static final String APACHE_CROSS_REF_URL2 = "http://www.apache.org/licenses/LICENSE-2.0";
     static final String APACHE_CROSS_REF_URL3 = "http://opensource.org/licenses/Apache-2.0";
+    static final String APACHE_CROSS_REF_URL4 = "http://opensource.org/license/apache-2-0";
     static final String APACHE_LICENSE_ID = "Apache-2.0";
     static final String APACHE_LICENSE_NAME = "Apache License 2.0";
     static final String APSL_CROSS_REF_URL = "http://www.opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/APPLE_LICENSE";
@@ -277,7 +278,8 @@ public class TestSpdxV2LicenseManager
         License result = licenseManager.spdxLicenseToMavenLicense( licenseInfo );
         assertEquals( result.getName(), ( (SpdxListedLicense) licenseInfo ).getName() );
         String resultUrl = result.getUrl().replace( "https", "http" );
-        assertTrue( APACHE_CROSS_REF_URL2.equals( resultUrl ) || APACHE_CROSS_REF_URL3.equals( resultUrl ) );
+        assertTrue( APACHE_CROSS_REF_URL2.equals( resultUrl ) || APACHE_CROSS_REF_URL3.equals( resultUrl ) ||
+                APACHE_CROSS_REF_URL4.equals( resultUrl ) );
 
         // non standard license
         final String LICENSE_ID = "LicenseRef-nonStd1";

--- a/src/test/java/org/spdx/maven/utils/TestSpdxV3LicenseManager.java
+++ b/src/test/java/org/spdx/maven/utils/TestSpdxV3LicenseManager.java
@@ -54,6 +54,7 @@ public class TestSpdxV3LicenseManager
     private static final String TEST_SPDX_DOCUMENT_URL = "http://www.spdx.org/documents/test";
     static final String APACHE_CROSS_REF_URL2 = "http://www.apache.org/licenses/LICENSE-2.0";
     static final String APACHE_CROSS_REF_URL3 = "http://opensource.org/licenses/Apache-2.0";
+    static final String APACHE_CROSS_REF_URL4 = "http://opensource.org/license/apache-2-0";
     static final String APACHE_LICENSE_ID = "Apache-2.0";
     static final String APACHE_LICENSE_NAME = "Apache License 2.0";
     static final String APSL_CROSS_REF_URL = "http://www.opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/APPLE_LICENSE";
@@ -288,7 +289,8 @@ public class TestSpdxV3LicenseManager
         License result = licenseManager.spdxLicenseToMavenLicense( licenseInfo );
         assertEquals( result.getName(), ( (ListedLicense) licenseInfo ).getName().get() );
         String resultUrl = result.getUrl().replace( "https", "http" );
-        assertTrue( APACHE_CROSS_REF_URL2.equals( resultUrl ) || APACHE_CROSS_REF_URL3.equals( resultUrl ) );
+        assertTrue( APACHE_CROSS_REF_URL2.equals( resultUrl ) || APACHE_CROSS_REF_URL3.equals( resultUrl ) ||
+                APACHE_CROSS_REF_URL4.equals( resultUrl ) );
 
         // non standard license
         final String LICENSE_ID = "LicenseRef-nonStd1";


### PR DESCRIPTION
Fixes #206 

Implements the following changes:
- Change how relative paths are calculated - Maven 4 was using an absolute path in place of a relative path used in Maven 3 causing a substring exception
- Replace the deprecated `@Component` references for project and session
- Fix some unrelated unit test failures - the license list URLs for Apache 2.0 were updated causing some random unit test failures