### PR TITLE
Change default file extension for SPDX V3 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ a unique license ID and the verbatim license text.
 
 See the file [`src/it/advanced/pom.xml`](src/it/advanced/pom.xml) for an example project using the spdx-maven-plugin.
 
+## File Naming Conventions
+
+The default output filename is `./target/site/{groupId}_{artifactId}-{version}.[extension]` where the `[extension]`
+is determined by the SPDX file output type:
+
+- `JSON` SPDX Spec version 2.3 (default) - `spdx.json`
+- `RDF/XML` SPDX Spec version 2.3 - `spdx.rdf.xml`
+- `JSON-LD` SPDX Spec version 3 - `spdx3.json`
+
+The output file name can be overridden using the `spdxFileName` property.
+
 ## Contributing
 
 See the [CONTRIBUTING.MD](CONTRIBUTING.md) documentation.

--- a/src/main/java/org/spdx/maven/CreateSpdxMojo.java
+++ b/src/main/java/org/spdx/maven/CreateSpdxMojo.java
@@ -107,14 +107,6 @@ public class CreateSpdxMojo extends AbstractMojo
 
     public static final String CREATOR_TOOL_MAVEN_PLUGIN = "Tool: spdx-maven-plugin";
 
-    public static final String SPDX_RDF_ARTIFACT_TYPE = "spdx.rdf.xml";
-
-    public static final String SPDX_JSON_ARTIFACT_TYPE = "spdx.json";
-
-    public static final String JSON_OUTPUT_FORMAT = "JSON";
-
-    public static final String RDF_OUTPUT_FORMAT = "RDF/XML";
-
     static
     {
         SpdxModelFactory.init();

--- a/src/main/java/org/spdx/maven/OutputFormat.java
+++ b/src/main/java/org/spdx/maven/OutputFormat.java
@@ -28,7 +28,7 @@ public enum OutputFormat
     
     RDF_XML("RDF/XML", "spdx.rdf.xml", ".rdf.xml", SpdxMajorVersion.VERSION_2),
     JSON("JSON", "spdx.json", ".json", SpdxMajorVersion.VERSION_2),
-    JSON_LD("JSON-LD", "spdx.json-ld.json", ".json-ld.json", SpdxMajorVersion.VERSION_3);
+    JSON_LD("JSON-LD", "spdx3.json", "3.json", SpdxMajorVersion.VERSION_3);
 
     private final String value;
     private final String artifactType;

--- a/src/test/java/org/spdx/maven/TestSpdxV3Mojo.java
+++ b/src/test/java/org/spdx/maven/TestSpdxV3Mojo.java
@@ -82,7 +82,7 @@ public class TestSpdxV3Mojo extends AbstractMojoTestCase
         assertTrue( spdxFile.exists() );
         // Test output artifact file is created
         File artifactFile = getTestFile(
-                "target/test-classes/unit/spdx-maven-plugin-test/spdx maven plugin test.spdx.json-ld.json" );
+                "target/test-classes/unit/spdx-maven-plugin-test/spdx maven plugin test.spdx3.json" );
         assertTrue( artifactFile.exists() );
         ISerializableModelStore modelStore = new JsonLDStore( new InMemSpdxStore() );
         ModelCopyManager copyManager = new ModelCopyManager();


### PR DESCRIPTION
The default file name for JSON-LD SPDX V3 files now matches the [IANA media type application](https://www.iana.org/assignments/media-types/application/spdx3+json).
This PR also improves the documentation for the file naming conventions.