### PR TITLE
#251: `aggregateSPDX` now also applies `licenseOverwrites`

### DIFF
--- a/src/it/aggregate-with-license-overwrite/pom.xml
+++ b/src/it/aggregate-with-license-overwrite/pom.xml
@@ -52,12 +52,12 @@
               <groupId>commons-collections</groupId>
               <artifactId>commons-collections</artifactId>
               <version>3.2.2</version>
-              <licenseString>LicenseRef-TEST_LICENSE</licenseString>
+              <licenseString>LicenseRef-TEST-LICENSE</licenseString>
             </licenseOverwrite>
           </licenseOverwrites>
           <nonStandardLicenses>
             <nonStandardLicense>
-              <licenseId>LicenseRef-TEST_LICENSE</licenseId>
+              <licenseId>LicenseRef-TEST-LICENSE</licenseId>
               <name>Test License</name>
               <extractedText>Test-only synthetic license text.</extractedText>
             </nonStandardLicense>

--- a/src/it/aggregate-with-license-overwrite/pom.xml
+++ b/src/it/aggregate-with-license-overwrite/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.spdx.it</groupId>
+  <artifactId>aggregate-with-license-overwrite</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <description>Regression test for aggregateSPDX license overwrites.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>3.2.2</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>aggregate-spdx</id>
+            <goals>
+              <goal>aggregateSPDX</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <outputFormat>JSON</outputFormat>
+          <onlyUseLocalLicenses>true</onlyUseLocalLicenses>
+          <licenseOverwrites>
+            <licenseOverwrite>
+              <target>both</target>
+              <groupId>commons-collections</groupId>
+              <artifactId>commons-collections</artifactId>
+              <version>3.2.2</version>
+              <licenseString>LicenseRef-TEST_LICENSE</licenseString>
+            </licenseOverwrite>
+          </licenseOverwrites>
+          <nonStandardLicenses>
+            <nonStandardLicense>
+              <licenseId>LicenseRef-TEST_LICENSE</licenseId>
+              <name>Test License</name>
+              <extractedText>Test-only synthetic license text.</extractedText>
+            </nonStandardLicense>
+          </nonStandardLicenses>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/aggregate-with-license-overwrite/verify.groovy
+++ b/src/it/aggregate-with-license-overwrite/verify.groovy
@@ -1,0 +1,18 @@
+File spdxFile = new File( basedir, "target/site/org.spdx.it_aggregate-with-license-overwrite-1.0-SNAPSHOT.spdx.json" )
+
+assert spdxFile.isFile()
+
+String content = spdxFile.text
+String marker = "\"referenceLocator\" : \"pkg:maven/commons-collections/commons-collections@3.2.2\""
+int packageStart = content.indexOf( marker )
+
+assert packageStart >= 0 : "Could not find commons-collections:3.2.2 in generated SPDX output"
+
+String packageBlock = content.substring( packageStart, Math.min( content.length(), packageStart + 400 ) )
+
+assert packageBlock.contains( "\"licenseDeclared\" : \"LicenseRef-TEST_LICENSE\"" ) :
+    "Expected commons-collections:3.2.2 to have licenseDeclared LicenseRef-TEST_LICENSE, but block was:\n" + packageBlock
+assert packageBlock.contains( "\"licenseConcluded\" : \"LicenseRef-TEST_LICENSE\"" ) :
+    "Expected commons-collections:3.2.2 to have licenseConcluded LicenseRef-TEST_LICENSE, but block was:\n" + packageBlock
+
+return true

--- a/src/it/aggregate-with-license-overwrite/verify.groovy
+++ b/src/it/aggregate-with-license-overwrite/verify.groovy
@@ -16,9 +16,9 @@ assert packageStart >= 0 : "Could not find commons-collections:3.2.2 in generate
 
 String packageBlock = content.substring( packageStart, Math.min( content.length(), packageStart + 400 ) )
 
-assert packageBlock.contains( "\"licenseDeclared\" : \"LicenseRef-TEST_LICENSE\"" ) :
-    "Expected commons-collections:3.2.2 to have licenseDeclared LicenseRef-TEST_LICENSE, but block was:\n" + packageBlock
-assert packageBlock.contains( "\"licenseConcluded\" : \"LicenseRef-TEST_LICENSE\"" ) :
-    "Expected commons-collections:3.2.2 to have licenseConcluded LicenseRef-TEST_LICENSE, but block was:\n" + packageBlock
+assert packageBlock.contains( "\"licenseDeclared\" : \"LicenseRef-TEST-LICENSE\"" ) :
+    "Expected commons-collections:3.2.2 to have licenseDeclared LicenseRef-TEST-LICENSE, but block was:\n" + packageBlock
+assert packageBlock.contains( "\"licenseConcluded\" : \"LicenseRef-TEST-LICENSE\"" ) :
+    "Expected commons-collections:3.2.2 to have licenseConcluded LicenseRef-TEST-LICENSE, but block was:\n" + packageBlock
 
 return true

--- a/src/it/aggregate-with-license-overwrite/verify.groovy
+++ b/src/it/aggregate-with-license-overwrite/verify.groovy
@@ -1,3 +1,9 @@
+/**
+ * Regression test for: https://github.com/spdx/spdx-maven-plugin/issues/251
+ *
+ * This test verifies that configured license overrides are applied when executing `aggregateSPDX`.
+ */
+
 File spdxFile = new File( basedir, "target/site/org.spdx.it_aggregate-with-license-overwrite-1.0-SNAPSHOT.spdx.json" )
 
 assert spdxFile.isFile()

--- a/src/it/aggregate-with-scope-filter/verify.groovy
+++ b/src/it/aggregate-with-scope-filter/verify.groovy
@@ -3,9 +3,6 @@
  *
  * This test verifies that dependencies with 'test' scope are excluded when
  * includeTestScope is set to false in the aggregateSPDX goal.
- * 
- * Note: This test is expected to fail because of a bug in the current implementation
- * where scope filters are not applied during aggregation.
  */
 
 File spdxFile = new File(basedir, "target/site/org.spdx.it_simple-it-1.0-SNAPSHOT.spdx.json")

--- a/src/main/java/org/spdx/maven/AggregateSpdxMojo.java
+++ b/src/main/java/org/spdx/maven/AggregateSpdxMojo.java
@@ -13,10 +13,6 @@ import org.spdx.core.InvalidSPDXAnalysisException;
 import org.spdx.maven.utils.AbstractDependencyBuilder;
 import org.spdx.maven.utils.AbstractDocumentBuilder;
 import org.spdx.maven.utils.LicenseMapperException;
-import org.spdx.maven.utils.SpdxV2DependencyBuilder;
-import org.spdx.maven.utils.SpdxV2DocumentBuilder;
-import org.spdx.maven.utils.SpdxV3DependencyBuilder;
-import org.spdx.maven.utils.SpdxV3DocumentBuilder;
 
 
 import java.util.List;
@@ -31,17 +27,7 @@ public class AggregateSpdxMojo extends CreateSpdxMojo {
     @Override
     protected void buildSpdxDependencyInformation( AbstractDocumentBuilder builder, OutputFormat outputFormatEnum )
             throws DependencyGraphBuilderException, LicenseMapperException, InvalidSPDXAnalysisException {
-        AbstractDependencyBuilder dependencyBuilder;
-        if ( builder instanceof SpdxV3DocumentBuilder)
-        {
-            dependencyBuilder = new SpdxV3DependencyBuilder( ( SpdxV3DocumentBuilder ) builder, createExternalRefs,
-                    generatePurls, useArtifactID, includeTransitiveDependencies );
-        }
-        else
-        {
-            dependencyBuilder = new SpdxV2DependencyBuilder( ( SpdxV2DocumentBuilder ) builder, createExternalRefs,
-                    generatePurls, useArtifactID, includeTransitiveDependencies );
-        }
+        AbstractDependencyBuilder dependencyBuilder = createDependencyBuilder( builder );
         if ( session != null )
         {
             List<MavenProject> projects = session.getAllProjects(); //includes the current project

--- a/src/main/java/org/spdx/maven/CreateSpdxMojo.java
+++ b/src/main/java/org/spdx/maven/CreateSpdxMojo.java
@@ -796,19 +796,19 @@ public class CreateSpdxMojo extends AbstractMojo
         org.spdx.library.model.v3_0_1.core.SpdxDocument spdxDoc = documentBuilder.getSpdxDoc();
         for ( LicenseOverwrite licenseOverwrite : licenseOverwrites )
         {
-            org.spdx.library.model.v3_0_1.simplelicensing.AnyLicenseInfo parsedLicense;
             try
             {
                 // parse the licenseString before use to fail fast with a broken configuration
-                parsedLicense = LicenseInfoFactory.parseSPDXLicenseString( licenseOverwrite.getLicenseString(),
+                org.spdx.library.model.v3_0_1.simplelicensing.AnyLicenseInfo parsedLicense
+                        = LicenseInfoFactory.parseSPDXLicenseString( licenseOverwrite.getLicenseString(),
                         spdxDoc.getModelStore(), spdxDoc.getIdPrefix(), spdxDoc.getCopyManager(), null );
+                dependencyBuilder.addLicenseOverwrite( licenseOverwrite, parsedLicense );
             }
             catch ( InvalidLicenseStringException e )
             {
                 // add some info the help the user fixing the configuration
                 throw new InvalidLicenseStringException( "Invalid license overwrite configuration for " + licenseOverwrite, e );
             }
-            dependencyBuilder.addLicenseOverwrite( licenseOverwrite, parsedLicense );
         }
     }
 
@@ -822,19 +822,19 @@ public class CreateSpdxMojo extends AbstractMojo
         org.spdx.library.model.v2.SpdxDocument spdxDoc = documentBuilder.getSpdxDoc();
         for ( LicenseOverwrite licenseOverwrite : licenseOverwrites )
         {
-            org.spdx.library.model.v2.license.AnyLicenseInfo parsedLicense;
             try
             {
                 // parse the licenseString before use to fail fast with a broken configuration
-                parsedLicense = LicenseInfoFactory.parseSPDXLicenseStringCompatV2( licenseOverwrite.getLicenseString(),
+                org.spdx.library.model.v2.license.AnyLicenseInfo parsedLicense =
+                        LicenseInfoFactory.parseSPDXLicenseStringCompatV2( licenseOverwrite.getLicenseString(),
                         spdxDoc.getModelStore(), spdxDoc.getDocumentUri(), spdxDoc.getCopyManager() );
+                dependencyBuilder.addLicenseOverwrite( licenseOverwrite, parsedLicense );
             }
             catch ( InvalidLicenseStringException e )
             {
                 // add some info the help the user fixing the configuration
                 throw new InvalidLicenseStringException( "Invalid license overwrite configuration for " + licenseOverwrite, e );
             }
-            dependencyBuilder.addLicenseOverwrite( licenseOverwrite, parsedLicense );
         }
     }
 

--- a/src/main/java/org/spdx/maven/CreateSpdxMojo.java
+++ b/src/main/java/org/spdx/maven/CreateSpdxMojo.java
@@ -755,75 +755,7 @@ public class CreateSpdxMojo extends AbstractMojo
     protected void buildSpdxDependencyInformation( AbstractDocumentBuilder builder, OutputFormat outputFormatEnum )
         throws LicenseMapperException, InvalidSPDXAnalysisException, DependencyGraphBuilderException
     {
-        AbstractDependencyBuilder dependencyBuilder;
-        if ( builder instanceof SpdxV3DocumentBuilder )
-        {
-            SpdxV3DocumentBuilder documentBuilder = (SpdxV3DocumentBuilder) builder;
-            SpdxV3DependencyBuilder dependencyBuilderV3 = new SpdxV3DependencyBuilder(
-                                                      documentBuilder, createExternalRefs,
-                                                      generatePurls, useArtifactID,
-                                                      includeTransitiveDependencies );
-            if ( licenseOverwrites != null )
-            {
-                org.spdx.library.model.v3_0_1.core.SpdxDocument spdxDoc = documentBuilder.getSpdxDoc();
-
-                for ( LicenseOverwrite licenseOverwrite : licenseOverwrites )
-                {
-                    org.spdx.library.model.v3_0_1.simplelicensing.AnyLicenseInfo parsedLicense;
-
-                    try
-                    {
-                        // parse the licenseString before use to fail fast with a broken configuration
-                        parsedLicense = LicenseInfoFactory.parseSPDXLicenseString(
-                                licenseOverwrite.getLicenseString(), spdxDoc.getModelStore(),
-                                spdxDoc.getIdPrefix(), spdxDoc.getCopyManager(), null );
-                    }
-                    catch ( InvalidLicenseStringException e )
-                    {
-                        // add some info the help the user fixing the configuration
-                        throw new InvalidLicenseStringException( "Invalid license overwrite configuration for " + licenseOverwrite, e );
-                    }
-
-                    dependencyBuilderV3.addLicenseOverwrite( licenseOverwrite, parsedLicense );
-                }
-            }
-            dependencyBuilder = dependencyBuilderV3;
-        }
-        else
-        {
-            SpdxV2DocumentBuilder documentBuilder = (SpdxV2DocumentBuilder) builder;
-            SpdxV2DependencyBuilder dependencyBuilderV2 = new SpdxV2DependencyBuilder(
-                                                      documentBuilder, createExternalRefs,
-                                                      generatePurls, useArtifactID,
-                                                      includeTransitiveDependencies );
-
-            if ( licenseOverwrites != null )
-            {
-                org.spdx.library.model.v2.SpdxDocument spdxDoc = documentBuilder.getSpdxDoc();
-
-                for ( LicenseOverwrite licenseOverwrite : licenseOverwrites )
-                {
-                    org.spdx.library.model.v2.license.AnyLicenseInfo parsedLicense;
-
-                    try
-                    {
-                        // parse the licenseString before use to fail fast with a broken configuration
-                        parsedLicense = LicenseInfoFactory.parseSPDXLicenseStringCompatV2(
-                                licenseOverwrite.getLicenseString(), spdxDoc.getModelStore(),
-                                spdxDoc.getDocumentUri(), spdxDoc.getCopyManager() );
-                    }
-                    catch ( InvalidLicenseStringException e )
-                    {
-                        // add some info the help the user fixing the configuration
-                        throw new InvalidLicenseStringException( "Invalid license overwrite configuration for " + licenseOverwrite, e );
-                    }
-
-                    dependencyBuilderV2.addLicenseOverwrite( licenseOverwrite, parsedLicense );
-                }
-            }
-
-            dependencyBuilder = dependencyBuilderV2;
-        }
+        AbstractDependencyBuilder dependencyBuilder = createDependencyBuilder( builder );
         if ( session != null )
         {
             ProjectBuildingRequest request = new DefaultProjectBuildingRequest( session.getProjectBuildingRequest() );
@@ -832,6 +764,77 @@ public class CreateSpdxMojo extends AbstractMojo
             DependencyNode parentNode = dependencyGraphBuilder.buildDependencyGraph( request, artifactFilter );
 
             dependencyBuilder.addMavenDependencies( mavenProjectBuilder, session, mavenProject, parentNode, builder.getProjectPackage() );
+        }
+    }
+
+    protected AbstractDependencyBuilder createDependencyBuilder( AbstractDocumentBuilder builder )
+            throws InvalidSPDXAnalysisException
+    {
+        if ( builder instanceof SpdxV3DocumentBuilder )
+        {
+            SpdxV3DocumentBuilder documentBuilder = (SpdxV3DocumentBuilder) builder;
+            SpdxV3DependencyBuilder dependencyBuilder = new SpdxV3DependencyBuilder(
+                    documentBuilder, createExternalRefs, generatePurls, useArtifactID, includeTransitiveDependencies );
+            addLicenseOverwrites( documentBuilder, dependencyBuilder );
+            return dependencyBuilder;
+        }
+
+        SpdxV2DocumentBuilder documentBuilder = (SpdxV2DocumentBuilder) builder;
+        SpdxV2DependencyBuilder dependencyBuilder = new SpdxV2DependencyBuilder(
+                documentBuilder, createExternalRefs, generatePurls, useArtifactID, includeTransitiveDependencies );
+        addLicenseOverwrites( documentBuilder, dependencyBuilder );
+        return dependencyBuilder;
+    }
+
+    private void addLicenseOverwrites( SpdxV3DocumentBuilder documentBuilder, SpdxV3DependencyBuilder dependencyBuilder )
+            throws InvalidSPDXAnalysisException
+    {
+        if ( licenseOverwrites == null )
+        {
+            return;
+        }
+        org.spdx.library.model.v3_0_1.core.SpdxDocument spdxDoc = documentBuilder.getSpdxDoc();
+        for ( LicenseOverwrite licenseOverwrite : licenseOverwrites )
+        {
+            org.spdx.library.model.v3_0_1.simplelicensing.AnyLicenseInfo parsedLicense;
+            try
+            {
+                // parse the licenseString before use to fail fast with a broken configuration
+                parsedLicense = LicenseInfoFactory.parseSPDXLicenseString( licenseOverwrite.getLicenseString(),
+                        spdxDoc.getModelStore(), spdxDoc.getIdPrefix(), spdxDoc.getCopyManager(), null );
+            }
+            catch ( InvalidLicenseStringException e )
+            {
+                // add some info the help the user fixing the configuration
+                throw new InvalidLicenseStringException( "Invalid license overwrite configuration for " + licenseOverwrite, e );
+            }
+            dependencyBuilder.addLicenseOverwrite( licenseOverwrite, parsedLicense );
+        }
+    }
+
+    private void addLicenseOverwrites( SpdxV2DocumentBuilder documentBuilder, SpdxV2DependencyBuilder dependencyBuilder )
+            throws InvalidSPDXAnalysisException
+    {
+        if ( licenseOverwrites == null )
+        {
+            return;
+        }
+        org.spdx.library.model.v2.SpdxDocument spdxDoc = documentBuilder.getSpdxDoc();
+        for ( LicenseOverwrite licenseOverwrite : licenseOverwrites )
+        {
+            org.spdx.library.model.v2.license.AnyLicenseInfo parsedLicense;
+            try
+            {
+                // parse the licenseString before use to fail fast with a broken configuration
+                parsedLicense = LicenseInfoFactory.parseSPDXLicenseStringCompatV2( licenseOverwrite.getLicenseString(),
+                        spdxDoc.getModelStore(), spdxDoc.getDocumentUri(), spdxDoc.getCopyManager() );
+            }
+            catch ( InvalidLicenseStringException e )
+            {
+                // add some info the help the user fixing the configuration
+                throw new InvalidLicenseStringException( "Invalid license overwrite configuration for " + licenseOverwrite, e );
+            }
+            dependencyBuilder.addLicenseOverwrite( licenseOverwrite, parsedLicense );
         }
     }
 


### PR DESCRIPTION
Added a regression test for `aggregateSPDX` ignoring configured license overrides.

Reduced code duplication between SPDX V2 / V3 in `AggregateSpdxMojo`. In `CreateSpdxMojo` extracted `createDependencyBuilder`.

Closes #251.

Transparency note: this change was done with the help of an LLM.