### PR TITLE
Add sonar plugin to build plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,11 @@
           <goals>deploy</goals>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.sonarsource.scanner.maven</groupId>
+        <artifactId>sonar-maven-plugin</artifactId>
+        <version>5.7.0.6970</version>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Sonar now requires fully qualified coordinates.  This fixes a CI failure when running Sonar.