### PR TITLE
Add exclude-paths configuration for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       day: "sunday"
     open-pull-requests-limit: 5
     rebase-strategy: "auto"
+    exclude-paths:
+      "/src/it/**"
     ignore:
       - dependency-name: "*"
         update-types:


### PR DESCRIPTION
Exclude paths under /src/it/ from Dependabot updates.